### PR TITLE
0.5.1: free-form section blocks on every entity

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,20 @@ All notable changes to the DSDS specification are documented in this file.
 
 ---
 
+## [0.5.1] — 2026-06-08
+
+Patch release on the `v0.5` schema URL — additive and non-breaking, so documents pinned to `https://designsystemdocspec.org/v0.5/...` keep validating and gain a new capability. Promotes the free-form `section` block to a general kind available on every entity.
+
+### Additions
+
+#### Free-form `section` blocks on every entity
+
+The `section` document block — titled, optionally nested narrative prose with a rich-text body, examples, and links — was previously accepted only on `guide` entities. It is now a **general** block kind, available on every entity type (component, foundation, pattern, token, guide). Use it for conceptual content the structured block kinds do not capture: rationale, background, decision history, and FAQs. Reach for a structured block kind first; use `section` only for the remainder.
+
+Internally, the per-entity document-block unions now reference a shared `generalDocumentBlock` definition instead of inlining the general kinds, so future general additions propagate to every entity from one place.
+
+---
+
 ## [0.5] — 2026-06-08
 
 Minor release. Schema files are now served at `https://designsystemdocspec.org/v0.5/...`. All earlier bundles remain published at their original URLs for documents pinned to them. This release renames the system-level `bestPractices` array to `guidelines`, aligning it with the guideline vocabulary the spec uses everywhere else.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system-documentation-schema",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A standard, machine-readable format for design system documentation.",
   "scripts": {
     "sync-examples": "node scripts/sync-examples.js",

--- a/scripts/render-summaries.js
+++ b/scripts/render-summaries.js
@@ -203,18 +203,31 @@ function blockContainer(def) {
 }
 
 // For every block def: which unions reference it → scope label.
+// Unions reference the general kinds indirectly, via a single
+// `generalDocumentBlock` branch. Expand that branch into its member kinds so
+// the general kinds (guideline, purpose, accessibility, content, section) are
+// attributed to every union that includes general, not lost one level down.
 function buildBlockScope(defs) {
   const generalNames = new Set(
-    ((defs.generalDocumentBlock && defs.generalDocumentBlock.oneOf) || []).map((o) => linkToRef(o.$ref)),
+    ((defs.generalDocumentBlock && defs.generalDocumentBlock.oneOf) || [])
+      .map((o) => linkToRef(o.$ref))
+      .filter(Boolean),
   );
   const scopeByBlock = {}; // block def name → Set of entity labels
+  const add = (block, label) => {
+    (scopeByBlock[block] = scopeByBlock[block] || new Set()).add(label);
+  };
   for (const union of UNION_ORDER) {
     const u = defs[union];
     if (!u) continue;
     for (const alt of u.oneOf || []) {
       const b = linkToRef(alt.$ref);
       if (!b) continue;
-      (scopeByBlock[b] = scopeByBlock[b] || new Set()).add(UNION_LABELS[union]);
+      if (b === "generalDocumentBlock") {
+        for (const g of generalNames) add(g, UNION_LABELS[union]);
+      } else {
+        add(b, UNION_LABELS[union]);
+      }
     }
   }
   return { generalNames, scopeByBlock };
@@ -316,10 +329,15 @@ function renderBlockScopeTable(opts = {}) {
 
   const rows = UNION_ORDER.filter((u) => defs[u]).map((union) => {
     const members = (defs[union].oneOf || []).map((o) => linkToRef(o.$ref)).filter(Boolean);
-    const nonGeneral = members.filter((m) => !generalNames.has(m));
-    const accepts = nonGeneral.length
-      ? nonGeneral.map((m) => code(kindConst(defs[m]) || m)).join(", ") + " + general"
-      : "general only";
+    // General kinds arrive via a `generalDocumentBlock` branch (or, legacy, inlined).
+    const hasGeneral =
+      members.includes("generalDocumentBlock") || members.some((m) => generalNames.has(m));
+    const specific = members.filter((m) => m !== "generalDocumentBlock" && !generalNames.has(m));
+    const accepts = specific.length
+      ? specific.map((m) => code(kindConst(defs[m]) || m)).join(", ") + (hasGeneral ? " + general" : "")
+      : hasGeneral
+        ? "general only"
+        : "—";
     return [
       `**${UNION_LABELS[union]}**`,
       (usedBy[union] || []).map(code).join(", ") || "—",

--- a/site/content/schema-architecture.mdx
+++ b/site/content/schema-architecture.mdx
@@ -320,7 +320,7 @@ Patterns reference their participating components through the `links` array (wit
 
 ### Guide
 
-A long-form, reading-oriented document — a getting-started walkthrough, contribution guide, tutorial, conceptual overview, or migration guide. Guides fill the gap left by the artifact-bound entities (which each document a single component, token, foundation, or pattern): they document a *journey* or a *concept* rather than one thing. Accepts **guide-scoped document block types** (section, steps), the `import` block, and all general document block types.
+A long-form, reading-oriented document — a getting-started walkthrough, contribution guide, tutorial, conceptual overview, or migration guide. Guides fill the gap left by the artifact-bound entities (which each document a single component, token, foundation, or pattern): they document a *journey* or a *concept* rather than one thing. Accepts the **guide-scoped** `steps` block, the `import` block, and all general document block types — including the free-form `section` block that forms the backbone of a guide.
 
 Required properties: `kind`, `identifier`, `name`. (`description` and `status` are optional `metadata` entries.)
 
@@ -436,11 +436,11 @@ Custom values are permitted (e.g., `"sunset"`, `"archived"`, `"beta"`) and MUST 
 
 Document block entries are the core unit of structured docs in DSDS. Every piece of docs on an entity is a document block object with a `kind` discriminator. Document block types cover:
 
-- guidelines, purpose, accessibility, and content (general — all entity types)
+- guidelines, purpose, accessibility, content, and narrative sections (general — all entity types)
 - anatomy, API specs, events, variants, states, design specifications, and import (component-scoped)
 - principles, scales, and motion definitions (foundation-scoped)
 - interactions (pattern-scoped)
-- narrative sections and step-by-step procedures (guide-scoped)
+- step-by-step procedures (guide-scoped)
 
 ### Scoped document block unions
 
@@ -450,11 +450,11 @@ Each entity type accepts only the document block types relevant to it. The scopi
 - **Patterns** get structural docs without code-level details — they have visual layouts (anatomy), sub-types (variants), and states, but they are not single-component code interfaces. They do not accept `api` or `design-specifications`.
 - **Foundations** get domain-level docs — they govern a visual or cross-cutting domain through guiding principles, constrained value progressions (scales), and motion definitions.
 - **Tokens** get only general document block types — they are atomic values with usage guidance but no visual structure or interaction behavior.
-- **Guides** get reading-oriented docs — narrative `section`s and step-by-step `steps` procedures, plus `import` for setup instructions. They carry no structural or measurable specs.
+- **Guides** get reading-oriented docs — step-by-step `steps` procedures plus `import` for setup instructions, and lean on the general `section` block for narrative prose. They carry no structural or measurable specs.
 
 <ds-block-scope-table />
 
-**General** (available on all entity types): guideline, purpose, accessibility, content.
+**General** (available on all entity types): guideline, purpose, accessibility, content, and section (free-form narrative prose).
 
 ### Document block types
 
@@ -552,6 +552,14 @@ At least one of `labels` or `localization` must be present.
 #### Localization entry
 
 <ds-prop-table schema="document-blocks/content" def="localizationEntry" />
+
+### Section (`section`)
+
+Free-form narrative prose organized into titled, optionally nested sections — the backbone of conceptual overviews, explanations, rationale, and any reading-oriented content the structured block kinds do not capture. Available on every entity type. Each `sectionEntry` pairs a `title` with an optional rich-text `body`, illustrative `examples`, related `links`, and recursive `sections` for a heading hierarchy. Reach for a structured block kind first; use `section` only for what they cannot express.
+
+#### Section entry
+
+<ds-prop-table schema="document-blocks/section" def="sectionEntry" />
 
 ---
 
@@ -727,15 +735,7 @@ Documents the interaction flow of a pattern as an ordered sequence of steps. The
 
 ## Guide-scoped document block types
 
-These document block types are accepted on **guide** entities (which also accept `import` and all general document block types). They favor reading-oriented prose and procedures over the measurable specs used by components.
-
-### Section (`section`)
-
-Narrative prose organized into titled, optionally nested sections — the backbone of conceptual overviews, explanations, and rationale. Each `sectionEntry` pairs a `title` with an optional rich-text `body`, illustrative `examples`, related `links`, and recursive `sections` for a heading hierarchy.
-
-#### Section entry
-
-<ds-prop-table schema="document-blocks/section" def="sectionEntry" />
+The `steps` block is accepted only on **guide** entities. Guides also accept `import` and every general document block type — including the free-form `section` block (documented above), which carries a guide's narrative prose.
 
 ### Steps (`steps`)
 

--- a/site/dist/document-blocks-document-blocks.html
+++ b/site/dist/document-blocks-document-blocks.html
@@ -77,31 +77,19 @@
   <div class="content content--with-toc">
     <main class="content__main" role="main">
       <div class="content__inner">
-        <ds-schema-header title="DSDS Document Block — Scoped Unions" description="Defines scoped document block unions, one per artifact type. Each piece of structured docs attached to an artifact is a document block object with a `type` tag. Block kinds include guidelines, anatomy, API specs, variants, states, accessibility, purpose, design specs, principles, scales, motion, content, and interactions. Each artifact type accepts only the relevant block kinds; this scoping prevents attaching irrelevant docs (such as an API spec on a foundation). Express internal artifact links through the unified `links` array on each entity, not through a dedicated block kind." source="document-blocks/document-blocks.schema.json"></ds-schema-header>
+        <ds-schema-header title="DSDS Document Block — Scoped Unions" description="Defines scoped document block unions, one per artifact type. Each piece of structured docs attached to an artifact is a document block object with a `kind` tag. Each artifact type accepts its own specialized block kinds plus every general kind (see `generalDocumentBlock`). General kinds — including the free-form `section` block — are available on every artifact; specialized kinds are scoped so irrelevant docs (such as an API spec on a foundation) cannot be attached. Express internal artifact links through the unified `links` array on each entity, not through a dedicated block kind." source="document-blocks/document-blocks.schema.json"></ds-schema-header>
 <ds-def-index>
 <p><strong>6 definitions</strong> in this file:</p>
 <ul>
-<li><a href="#generaldocumentblock"><ds-code inline>generalDocumentBlock</ds-code></a></li>
 <li><a href="#componentdocumentblock"><ds-code inline>componentDocumentBlock</ds-code></a></li>
 <li><a href="#foundationdocumentblock"><ds-code inline>foundationDocumentBlock</ds-code></a></li>
 <li><a href="#patterndocumentblock"><ds-code inline>patternDocumentBlock</ds-code></a></li>
 <li><a href="#tokendocumentblock"><ds-code inline>tokenDocumentBlock</ds-code></a></li>
 <li><a href="#guidedocumentblock"><ds-code inline>guideDocumentBlock</ds-code></a></li>
+<li><a href="#generaldocumentblock"><ds-code inline>generalDocumentBlock</ds-code></a></li>
 </ul>
 </ds-def-index>
-<ds-def-section name="generalDocumentBlock" anchor="generaldocumentblock" description="A document block kind available on every artifact type. General blocks cover cross-cutting concerns that apply to any artifact.">
-<p><strong>Accepts one of:</strong></p>
-<ul>
-<li><a href="document-blocks-guideline.html#guideline">guideline</a></li>
-<li><a href="common-purpose.html#purpose">purpose</a></li>
-<li><a href="document-blocks-accessibility.html#accessibility">accessibility</a></li>
-<li><a href="document-blocks-content.html#content">content</a></li>
-</ul>
-<ds-cross-refs><strong>References:</strong> 
-<ds-type-ref href="document-blocks-guideline.html#guideline">guideline</ds-type-ref>, <ds-type-ref href="common-purpose.html#purpose">purpose</ds-type-ref>, <ds-type-ref href="document-blocks-accessibility.html#accessibility">accessibility</ds-type-ref>, <ds-type-ref href="document-blocks-content.html#content">content</ds-type-ref>
-</ds-cross-refs>
-</ds-def-section>
-<ds-def-section name="componentDocumentBlock" anchor="componentdocumentblock" description="A document block kind accepted on component artifacts. Includes the component-specific kinds (anatomy, API, variants, states, design specs) plus every general kind.">
+<ds-def-section name="componentDocumentBlock" anchor="componentdocumentblock" description="A document block kind accepted on component artifacts. Includes the component-specific kinds (import, anatomy, API, events, variants, states, design specs) plus every general kind.">
 <p><strong>Accepts one of:</strong></p>
 <ul>
 <li><a href="document-blocks-import.html#import">import</a></li>
@@ -111,13 +99,10 @@
 <li><a href="document-blocks-variant.html#variants">variants</a></li>
 <li><a href="document-blocks-state.html#states">states</a></li>
 <li><a href="document-blocks-design-specifications.html#designspecifications">designSpecifications</a></li>
-<li><a href="document-blocks-guideline.html#guideline">guideline</a></li>
-<li><a href="common-purpose.html#purpose">purpose</a></li>
-<li><a href="document-blocks-accessibility.html#accessibility">accessibility</a></li>
-<li><a href="document-blocks-content.html#content">content</a></li>
+<li><a href="document-blocks-document-blocks.html#generaldocumentblock">generalDocumentBlock</a></li>
 </ul>
 <ds-cross-refs><strong>References:</strong> 
-<ds-type-ref href="document-blocks-import.html#import">import</ds-type-ref>, <ds-type-ref href="document-blocks-anatomy.html#anatomy">anatomy</ds-type-ref>, <ds-type-ref href="document-blocks-api.html#api">api</ds-type-ref>, <ds-type-ref href="document-blocks-events.html#events">events</ds-type-ref>, <ds-type-ref href="document-blocks-variant.html#variants">variants</ds-type-ref>, <ds-type-ref href="document-blocks-state.html#states">states</ds-type-ref>, <ds-type-ref href="document-blocks-design-specifications.html#designspecifications">designSpecifications</ds-type-ref>, <ds-type-ref href="document-blocks-guideline.html#guideline">guideline</ds-type-ref>, <ds-type-ref href="common-purpose.html#purpose">purpose</ds-type-ref>, <ds-type-ref href="document-blocks-accessibility.html#accessibility">accessibility</ds-type-ref>, <ds-type-ref href="document-blocks-content.html#content">content</ds-type-ref>
+<ds-type-ref href="document-blocks-import.html#import">import</ds-type-ref>, <ds-type-ref href="document-blocks-anatomy.html#anatomy">anatomy</ds-type-ref>, <ds-type-ref href="document-blocks-api.html#api">api</ds-type-ref>, <ds-type-ref href="document-blocks-events.html#events">events</ds-type-ref>, <ds-type-ref href="document-blocks-variant.html#variants">variants</ds-type-ref>, <ds-type-ref href="document-blocks-state.html#states">states</ds-type-ref>, <ds-type-ref href="document-blocks-design-specifications.html#designspecifications">designSpecifications</ds-type-ref>, <ds-type-ref href="document-blocks-document-blocks.html#generaldocumentblock">generalDocumentBlock</ds-type-ref>
 </ds-cross-refs>
 </ds-def-section>
 <ds-def-section name="foundationDocumentBlock" anchor="foundationdocumentblock" description="A document block kind accepted on foundation artifacts. Includes the foundation-specific kinds (principles, scales, motion) plus every general kind.">
@@ -126,16 +111,13 @@
 <li><a href="document-blocks-principle.html#principles">principles</a></li>
 <li><a href="document-blocks-scale.html#scale">scale</a></li>
 <li><a href="document-blocks-motion.html#motion">motion</a></li>
-<li><a href="document-blocks-guideline.html#guideline">guideline</a></li>
-<li><a href="common-purpose.html#purpose">purpose</a></li>
-<li><a href="document-blocks-accessibility.html#accessibility">accessibility</a></li>
-<li><a href="document-blocks-content.html#content">content</a></li>
+<li><a href="document-blocks-document-blocks.html#generaldocumentblock">generalDocumentBlock</a></li>
 </ul>
 <ds-cross-refs><strong>References:</strong> 
-<ds-type-ref href="document-blocks-principle.html#principles">principles</ds-type-ref>, <ds-type-ref href="document-blocks-scale.html#scale">scale</ds-type-ref>, <ds-type-ref href="document-blocks-motion.html#motion">motion</ds-type-ref>, <ds-type-ref href="document-blocks-guideline.html#guideline">guideline</ds-type-ref>, <ds-type-ref href="common-purpose.html#purpose">purpose</ds-type-ref>, <ds-type-ref href="document-blocks-accessibility.html#accessibility">accessibility</ds-type-ref>, <ds-type-ref href="document-blocks-content.html#content">content</ds-type-ref>
+<ds-type-ref href="document-blocks-principle.html#principles">principles</ds-type-ref>, <ds-type-ref href="document-blocks-scale.html#scale">scale</ds-type-ref>, <ds-type-ref href="document-blocks-motion.html#motion">motion</ds-type-ref>, <ds-type-ref href="document-blocks-document-blocks.html#generaldocumentblock">generalDocumentBlock</ds-type-ref>
 </ds-cross-refs>
 </ds-def-section>
-<ds-def-section name="patternDocumentBlock" anchor="patterndocumentblock" description="A document block kind accepted on pattern artifacts. Includes the pattern-specific kinds (interactions), shared structural kinds (anatomy, variants, states), and every general kind.">
+<ds-def-section name="patternDocumentBlock" anchor="patterndocumentblock" description="A document block kind accepted on pattern artifacts. Includes the pattern-specific kind (interactions), shared structural kinds (anatomy, variants, states, events), and every general kind.">
 <p><strong>Accepts one of:</strong></p>
 <ul>
 <li><a href="document-blocks-interaction.html#interactions">interactions</a></li>
@@ -143,40 +125,43 @@
 <li><a href="document-blocks-variant.html#variants">variants</a></li>
 <li><a href="document-blocks-state.html#states">states</a></li>
 <li><a href="document-blocks-events.html#events">events</a></li>
-<li><a href="document-blocks-guideline.html#guideline">guideline</a></li>
-<li><a href="common-purpose.html#purpose">purpose</a></li>
-<li><a href="document-blocks-accessibility.html#accessibility">accessibility</a></li>
-<li><a href="document-blocks-content.html#content">content</a></li>
+<li><a href="document-blocks-document-blocks.html#generaldocumentblock">generalDocumentBlock</a></li>
 </ul>
 <ds-cross-refs><strong>References:</strong> 
-<ds-type-ref href="document-blocks-interaction.html#interactions">interactions</ds-type-ref>, <ds-type-ref href="document-blocks-anatomy.html#anatomy">anatomy</ds-type-ref>, <ds-type-ref href="document-blocks-variant.html#variants">variants</ds-type-ref>, <ds-type-ref href="document-blocks-state.html#states">states</ds-type-ref>, <ds-type-ref href="document-blocks-events.html#events">events</ds-type-ref>, <ds-type-ref href="document-blocks-guideline.html#guideline">guideline</ds-type-ref>, <ds-type-ref href="common-purpose.html#purpose">purpose</ds-type-ref>, <ds-type-ref href="document-blocks-accessibility.html#accessibility">accessibility</ds-type-ref>, <ds-type-ref href="document-blocks-content.html#content">content</ds-type-ref>
+<ds-type-ref href="document-blocks-interaction.html#interactions">interactions</ds-type-ref>, <ds-type-ref href="document-blocks-anatomy.html#anatomy">anatomy</ds-type-ref>, <ds-type-ref href="document-blocks-variant.html#variants">variants</ds-type-ref>, <ds-type-ref href="document-blocks-state.html#states">states</ds-type-ref>, <ds-type-ref href="document-blocks-events.html#events">events</ds-type-ref>, <ds-type-ref href="document-blocks-document-blocks.html#generaldocumentblock">generalDocumentBlock</ds-type-ref>
 </ds-cross-refs>
 </ds-def-section>
-<ds-def-section name="tokenDocumentBlock" anchor="tokendocumentblock" description="A document block kind accepted on token and token group artifacts. Tokens use only the general kinds; they do not have component-specific, foundation-specific, or pattern-specific docs.">
+<ds-def-section name="tokenDocumentBlock" anchor="tokendocumentblock" description="A document block kind accepted on token and token group artifacts. Tokens carry no component-, foundation-, or pattern-specific docs — only the general kinds (guideline, purpose, accessibility, content, and free-form sections).">
 <p><strong>Accepts one of:</strong></p>
 <ul>
-<li><a href="document-blocks-guideline.html#guideline">guideline</a></li>
-<li><a href="common-purpose.html#purpose">purpose</a></li>
-<li><a href="document-blocks-accessibility.html#accessibility">accessibility</a></li>
-<li><a href="document-blocks-content.html#content">content</a></li>
+<li><a href="document-blocks-document-blocks.html#generaldocumentblock">generalDocumentBlock</a></li>
 </ul>
 <ds-cross-refs><strong>References:</strong> 
-<ds-type-ref href="document-blocks-guideline.html#guideline">guideline</ds-type-ref>, <ds-type-ref href="common-purpose.html#purpose">purpose</ds-type-ref>, <ds-type-ref href="document-blocks-accessibility.html#accessibility">accessibility</ds-type-ref>, <ds-type-ref href="document-blocks-content.html#content">content</ds-type-ref>
+<ds-type-ref href="document-blocks-document-blocks.html#generaldocumentblock">generalDocumentBlock</ds-type-ref>
 </ds-cross-refs>
 </ds-def-section>
-<ds-def-section name="guideDocumentBlock" anchor="guidedocumentblock" description="A document block kind accepted on guide artifacts. Includes the guide-specific narrative kinds (section, steps) plus reused kinds: import (for setup and install instructions), and every general kind. Guides are reading-oriented, so their blocks favor prose and procedures over the measurable specs (api, anatomy, design specs) used by components.">
+<ds-def-section name="guideDocumentBlock" anchor="guidedocumentblock" description="A document block kind accepted on guide artifacts. Includes the guide-specific procedure kind (steps), the reused import kind (setup and install instructions), and every general kind — among them the free-form `section` block that forms the backbone of conceptual guides. Guides are reading-oriented, so their blocks favor prose and procedures over the measurable specs (api, anatomy, design specs) used by components.">
 <p><strong>Accepts one of:</strong></p>
 <ul>
-<li><a href="document-blocks-section.html#section">section</a></li>
 <li><a href="document-blocks-steps.html#steps">steps</a></li>
 <li><a href="document-blocks-import.html#import">import</a></li>
+<li><a href="document-blocks-document-blocks.html#generaldocumentblock">generalDocumentBlock</a></li>
+</ul>
+<ds-cross-refs><strong>References:</strong> 
+<ds-type-ref href="document-blocks-steps.html#steps">steps</ds-type-ref>, <ds-type-ref href="document-blocks-import.html#import">import</ds-type-ref>, <ds-type-ref href="document-blocks-document-blocks.html#generaldocumentblock">generalDocumentBlock</ds-type-ref>
+</ds-cross-refs>
+</ds-def-section>
+<ds-def-section name="generalDocumentBlock" anchor="generaldocumentblock" description="A document block kind available on every artifact type. General blocks cover cross-cutting concerns that apply to any artifact, including free-form narrative prose. Every scoped union includes these kinds by referencing this definition.">
+<p><strong>Accepts one of:</strong></p>
+<ul>
 <li><a href="document-blocks-guideline.html#guideline">guideline</a></li>
 <li><a href="common-purpose.html#purpose">purpose</a></li>
 <li><a href="document-blocks-accessibility.html#accessibility">accessibility</a></li>
 <li><a href="document-blocks-content.html#content">content</a></li>
+<li><a href="document-blocks-section.html#section">section</a></li>
 </ul>
 <ds-cross-refs><strong>References:</strong> 
-<ds-type-ref href="document-blocks-section.html#section">section</ds-type-ref>, <ds-type-ref href="document-blocks-steps.html#steps">steps</ds-type-ref>, <ds-type-ref href="document-blocks-import.html#import">import</ds-type-ref>, <ds-type-ref href="document-blocks-guideline.html#guideline">guideline</ds-type-ref>, <ds-type-ref href="common-purpose.html#purpose">purpose</ds-type-ref>, <ds-type-ref href="document-blocks-accessibility.html#accessibility">accessibility</ds-type-ref>, <ds-type-ref href="document-blocks-content.html#content">content</ds-type-ref>
+<ds-type-ref href="document-blocks-guideline.html#guideline">guideline</ds-type-ref>, <ds-type-ref href="common-purpose.html#purpose">purpose</ds-type-ref>, <ds-type-ref href="document-blocks-accessibility.html#accessibility">accessibility</ds-type-ref>, <ds-type-ref href="document-blocks-content.html#content">content</ds-type-ref>, <ds-type-ref href="document-blocks-section.html#section">section</ds-type-ref>
 </ds-cross-refs>
 </ds-def-section>
 

--- a/site/dist/entities-foundation.html
+++ b/site/dist/entities-foundation.html
@@ -467,6 +467,23 @@
           &quot;gaps&quot;
         ]
       }
+    },
+    {
+      &quot;kind&quot;: &quot;section&quot;,
+      &quot;items&quot;: [
+        {
+          &quot;title&quot;: &quot;Why a 4px base unit&quot;,
+          &quot;anchor&quot;: &quot;why-4px-base&quot;,
+          &quot;body&quot;: &quot;The scale is built on a 4px base. Doubling and adding from that base keeps adjacent steps visually distinct while staying dense enough for data-heavy UI. A 4px grid also aligns cleanly with common icon and line-height values, so spacing and typography share one rhythm.&quot;,
+          &quot;sections&quot;: [
+            {
+              &quot;title&quot;: &quot;When to break the scale&quot;,
+              &quot;anchor&quot;: &quot;breaking-the-scale&quot;,
+              &quot;body&quot;: &quot;Deviate only for optical alignment the scale cannot express — for example, nudging an icon by 1px so it sits on its baseline. Document any such exception next to the component that needs it.&quot;
+            }
+          ]
+        }
+      ]
     }
   ],
   &quot;agents&quot;: {

--- a/site/dist/entities-pattern.html
+++ b/site/dist/entities-pattern.html
@@ -563,6 +563,16 @@
           &quot;a11y&quot;
         ]
       }
+    },
+    {
+      &quot;kind&quot;: &quot;section&quot;,
+      &quot;items&quot;: [
+        {
+          &quot;title&quot;: &quot;Why centralize error messaging&quot;,
+          &quot;anchor&quot;: &quot;why-centralize&quot;,
+          &quot;body&quot;: &quot;Errors surface across forms, asynchronous actions, and failed page loads. Centralizing the rules keeps tone, placement, and recovery consistent, so users learn a single mental model for \&quot;something went wrong\&quot; instead of relearning it on every surface.&quot;
+        }
+      ]
     }
   ],
   &quot;agents&quot;: {

--- a/site/dist/quickstart.html
+++ b/site/dist/quickstart.html
@@ -184,6 +184,7 @@
 <tr><td><ds-code inline>content</ds-code></td><td>all</td><td>Structured content guidelines: recommended action labels and localization considerations.</td></tr>
 <tr><td><ds-code inline>guideline</ds-code></td><td>all</td><td>Actionable usage rules for an artifact.</td></tr>
 <tr><td><ds-code inline>purpose</ds-code></td><td>all</td><td>Documents the purpose of an artifact — when to use it and when to choose something else.</td></tr>
+<tr><td><ds-code inline>section</ds-code></td><td>all</td><td>A block of narrative documentation made up of one or more titled sections.</td></tr>
 <tr><td><ds-code inline>import</ds-code></td><td>component, guide</td><td>Documents how to import a component across platforms.</td></tr>
 <tr><td><ds-code inline>anatomy</ds-code></td><td>component, pattern</td><td>Documents the visual structure of a component or pattern by listing its named sub-elements (parts).</td></tr>
 <tr><td><ds-code inline>events</ds-code></td><td>component, pattern</td><td>Documents the events emitted by a component as a dedicated document block.</td></tr>
@@ -194,7 +195,6 @@
 <tr><td><ds-code inline>motion</ds-code></td><td>foundation</td><td>Documents the motion system for a foundation — named easing curves, timing functions, recommended durations, and usage guidance.</td></tr>
 <tr><td><ds-code inline>principles</ds-code></td><td>foundation</td><td>Documents guiding principles for a foundation or design domain.</td></tr>
 <tr><td><ds-code inline>scale</ds-code></td><td>foundation</td><td>Documents an ordered scale — a deliberate progression of values that constrains design decisions to a harmonious, consistent set.</td></tr>
-<tr><td><ds-code inline>section</ds-code></td><td>guide</td><td>A block of narrative documentation made up of one or more titled sections.</td></tr>
 <tr><td><ds-code inline>steps</ds-code></td><td>guide</td><td>A procedure made up of an ordered or unordered sequence of steps.</td></tr>
 <tr><td><ds-code inline>interactions</ds-code></td><td>pattern</td><td>Documents the interaction flow of a pattern as an ordered sequence of steps.</td></tr></tbody>
 </table>

--- a/site/dist/schema-architecture.html
+++ b/site/dist/schema-architecture.html
@@ -412,7 +412,7 @@
 <p>Required properties: <ds-code inline>kind</ds-code>, <ds-code inline>identifier</ds-code>, <ds-code inline>name</ds-code>. (<ds-code inline>description</ds-code> and <ds-code inline>status</ds-code> are optional <ds-code inline>metadata</ds-code> entries — see <a href="#entity-metadata">Entity metadata</a>.)</p>
 <p>Patterns reference their participating components through the <ds-code inline>links</ds-code> array (with <ds-code inline>kind: "component"</ds-code>, <ds-code inline>identifier</ds-code>, and <ds-code inline>role</ds-code>) instead of through a dedicated document block.</p>
 <ds-heading level="3" anchor="guide">Guide</ds-heading>
-<p>A long-form, reading-oriented document — a getting-started walkthrough, contribution guide, tutorial, conceptual overview, or migration guide. Guides fill the gap left by the artifact-bound entities (which each document a single component, token, foundation, or pattern): they document a <em>journey</em> or a <em>concept</em> rather than one thing. Accepts <strong>guide-scoped document block types</strong> (section, steps), the <ds-code inline>import</ds-code> block, and all general document block types.</p>
+<p>A long-form, reading-oriented document — a getting-started walkthrough, contribution guide, tutorial, conceptual overview, or migration guide. Guides fill the gap left by the artifact-bound entities (which each document a single component, token, foundation, or pattern): they document a <em>journey</em> or a <em>concept</em> rather than one thing. Accepts the <strong>guide-scoped</strong> <ds-code inline>steps</ds-code> block, the <ds-code inline>import</ds-code> block, and all general document block types — including the free-form <ds-code inline>section</ds-code> block that forms the backbone of a guide.</p>
 <p>Required properties: <ds-code inline>kind</ds-code>, <ds-code inline>identifier</ds-code>, <ds-code inline>name</ds-code>. (<ds-code inline>description</ds-code> and <ds-code inline>status</ds-code> are optional <ds-code inline>metadata</ds-code> entries.)</p>
 <p>The <em>kind</em> of guide (getting-started, contribution, tutorial, concept, migration) is expressed through a <ds-code inline>category</ds-code> metadata entry, keeping the entity flexible enough for any kind of guidance.</p>
 <hr />
@@ -517,11 +517,11 @@
 <ds-heading level="2" anchor="document-block">Document block</ds-heading>
 <p>Document block entries are the core unit of structured docs in DSDS. Every piece of docs on an entity is a document block object with a <ds-code inline>kind</ds-code> discriminator. Document block types cover:</p>
 <ul>
-<li>guidelines, purpose, accessibility, and content (general — all entity types)</li>
+<li>guidelines, purpose, accessibility, content, and narrative sections (general — all entity types)</li>
 <li>anatomy, API specs, events, variants, states, design specifications, and import (component-scoped)</li>
 <li>principles, scales, and motion definitions (foundation-scoped)</li>
 <li>interactions (pattern-scoped)</li>
-<li>narrative sections and step-by-step procedures (guide-scoped)</li>
+<li>step-by-step procedures (guide-scoped)</li>
 </ul>
 <ds-heading level="3" anchor="scoped-document-block-unions">Scoped document block unions</ds-heading>
 <p>Each entity type accepts only the document block types relevant to it. The scoping rationale:</p>
@@ -530,7 +530,7 @@
 <li><strong>Patterns</strong> get structural docs without code-level details — they have visual layouts (anatomy), sub-types (variants), and states, but they are not single-component code interfaces. They do not accept <ds-code inline>api</ds-code> or <ds-code inline>design-specifications</ds-code>.</li>
 <li><strong>Foundations</strong> get domain-level docs — they govern a visual or cross-cutting domain through guiding principles, constrained value progressions (scales), and motion definitions.</li>
 <li><strong>Tokens</strong> get only general document block types — they are atomic values with usage guidance but no visual structure or interaction behavior.</li>
-<li><strong>Guides</strong> get reading-oriented docs — narrative <ds-code inline>section</ds-code>s and step-by-step <ds-code inline>steps</ds-code> procedures, plus <ds-code inline>import</ds-code> for setup instructions. They carry no structural or measurable specs.</li>
+<li><strong>Guides</strong> get reading-oriented docs — step-by-step <ds-code inline>steps</ds-code> procedures plus <ds-code inline>import</ds-code> for setup instructions, and lean on the general <ds-code inline>section</ds-code> block for narrative prose. They carry no structural or measurable specs.</li>
 </ul>
 <ds-table>
 <table>
@@ -538,11 +538,11 @@
 <tbody><tr><td><strong>Component</strong></td><td><ds-code inline>component</ds-code></td><td><ds-code inline>import</ds-code>, <ds-code inline>anatomy</ds-code>, <ds-code inline>api</ds-code>, <ds-code inline>events</ds-code>, <ds-code inline>variants</ds-code>, <ds-code inline>states</ds-code>, <ds-code inline>design-specifications</ds-code> + general</td></tr>
 <tr><td><strong>Pattern</strong></td><td><ds-code inline>pattern</ds-code></td><td><ds-code inline>interactions</ds-code>, <ds-code inline>anatomy</ds-code>, <ds-code inline>variants</ds-code>, <ds-code inline>states</ds-code>, <ds-code inline>events</ds-code> + general</td></tr>
 <tr><td><strong>Foundation</strong></td><td><ds-code inline>foundation</ds-code></td><td><ds-code inline>principles</ds-code>, <ds-code inline>scale</ds-code>, <ds-code inline>motion</ds-code> + general</td></tr>
-<tr><td><strong>Guide</strong></td><td><ds-code inline>guide</ds-code></td><td><ds-code inline>section</ds-code>, <ds-code inline>steps</ds-code>, <ds-code inline>import</ds-code> + general</td></tr>
+<tr><td><strong>Guide</strong></td><td><ds-code inline>guide</ds-code></td><td><ds-code inline>steps</ds-code>, <ds-code inline>import</ds-code> + general</td></tr>
 <tr><td><strong>Token</strong></td><td><ds-code inline>theme</ds-code>, <ds-code inline>token</ds-code>, <ds-code inline>token-group</ds-code></td><td>general only</td></tr></tbody>
 </table>
 </ds-table>
-<p><strong>General</strong> (available on all entity types): guideline, purpose, accessibility, content.</p>
+<p><strong>General</strong> (available on all entity types): guideline, purpose, accessibility, content, and section (free-form narrative prose).</p>
 <ds-heading level="3" anchor="document-block-types">Document block types</ds-heading>
 <ds-table>
 <table>
@@ -551,6 +551,7 @@
 <tr><td><ds-code inline>&quot;content&quot;</ds-code></td><td>Named properties</td><td>various</td><td>General</td><td>Structured content guidelines: recommended action labels and localization considerations.</td></tr>
 <tr><td><ds-code inline>&quot;guideline&quot;</ds-code></td><td><ds-code inline>items</ds-code></td><td><ds-type-ref href="document-blocks-guideline.html#guidelineentry">guidelineEntry</ds-type-ref></td><td>General</td><td>Actionable usage rules for an artifact.</td></tr>
 <tr><td><ds-code inline>&quot;purpose&quot;</ds-code></td><td><ds-code inline>useCases</ds-code></td><td><ds-type-ref href="common-purpose.html#usecase">useCase</ds-type-ref></td><td>General</td><td>Documents the purpose of an artifact — when to use it and when to choose something else.</td></tr>
+<tr><td><ds-code inline>&quot;section&quot;</ds-code></td><td><ds-code inline>items</ds-code></td><td><ds-type-ref href="document-blocks-section.html#sectionentry">sectionEntry</ds-type-ref></td><td>General</td><td>A block of narrative documentation made up of one or more titled sections.</td></tr>
 <tr><td><ds-code inline>&quot;import&quot;</ds-code></td><td><ds-code inline>items</ds-code></td><td><ds-type-ref href="document-blocks-import.html#importentry">importEntry</ds-type-ref></td><td>Component, Guide</td><td>Documents how to import a component across platforms.</td></tr>
 <tr><td><ds-code inline>&quot;anatomy&quot;</ds-code></td><td>Named properties</td><td>various</td><td>Component, Pattern</td><td>Documents the visual structure of a component or pattern by listing its named sub-elements (parts).</td></tr>
 <tr><td><ds-code inline>&quot;events&quot;</ds-code></td><td><ds-code inline>items</ds-code></td><td><ds-type-ref href="document-blocks-events.html#evententry">eventEntry</ds-type-ref></td><td>Component, Pattern</td><td>Documents the events emitted by a component as a dedicated document block.</td></tr>
@@ -561,7 +562,6 @@
 <tr><td><ds-code inline>&quot;motion&quot;</ds-code></td><td><ds-code inline>items</ds-code></td><td><ds-type-ref href="document-blocks-motion.html#motionentry">motionEntry</ds-type-ref></td><td>Foundation</td><td>Documents the motion system for a foundation — named easing curves, timing functions, recommended durations, and usage guidance.</td></tr>
 <tr><td><ds-code inline>&quot;principles&quot;</ds-code></td><td><ds-code inline>items</ds-code></td><td><ds-type-ref href="document-blocks-principle.html#principleentry">principleEntry</ds-type-ref></td><td>Foundation</td><td>Documents guiding principles for a foundation or design domain.</td></tr>
 <tr><td><ds-code inline>&quot;scale&quot;</ds-code></td><td><ds-code inline>steps</ds-code></td><td><ds-type-ref href="document-blocks-scale.html#scalestep">scaleStep</ds-type-ref></td><td>Foundation</td><td>Documents an ordered scale — a deliberate progression of values that constrains design decisions to a harmonious, consistent set.</td></tr>
-<tr><td><ds-code inline>&quot;section&quot;</ds-code></td><td><ds-code inline>items</ds-code></td><td><ds-type-ref href="document-blocks-section.html#sectionentry">sectionEntry</ds-type-ref></td><td>Guide</td><td>A block of narrative documentation made up of one or more titled sections.</td></tr>
 <tr><td><ds-code inline>&quot;steps&quot;</ds-code></td><td><ds-code inline>items</ds-code></td><td><ds-type-ref href="document-blocks-steps.html#stepentry">stepEntry</ds-type-ref></td><td>Guide</td><td>A procedure made up of an ordered or unordered sequence of steps.</td></tr>
 <tr><td><ds-code inline>&quot;interactions&quot;</ds-code></td><td><ds-code inline>items</ds-code></td><td><ds-type-ref href="document-blocks-interaction.html#interactionentry">interactionEntry</ds-type-ref></td><td>Pattern</td><td>Documents the interaction flow of a pattern as an ordered sequence of steps.</td></tr></tbody>
 </table>
@@ -654,6 +654,17 @@
   <ds-prop name="concern" type="string" required>The localization concern being addressed. Standard values: 'rtl' (right-to-left layout mirroring and bidirectional text), 'text-expansion' (content lengthening during translation), 'pluralization' (plural forms varying across languages), 'date-format' (date and time formatting conventions), 'number-format' (decimal separators, grouping), 'currency' (currency symbol placement and formatting), 'text-direction' (mixed-direction content within a single string), 'icon-direction' (icons that imply directionality), 'truncation' (text overflow behavior across languages), 'sorting' (locale-specific sort order and collation), 'concatenation' (avoiding string concatenation that breaks in other languages). Custom values are allowed and SHOULD be lowercase kebab-case.</ds-prop>
   <ds-prop name="description" type="&lt;ds-type-ref href=&quot;common-rich-text.html#richtext&quot;&gt;richText&lt;/ds-type-ref&gt;" required>Guidance for handling this localization concern. Should be actionable and specific: say what changes across locales, what the author or developer must do, and what to avoid.</ds-prop>
   <ds-prop name="examples" type="&lt;ds-type-ref href=&quot;common-example.html#example&quot;&gt;example&lt;/ds-type-ref&gt;[]">Visual or code examples that illustrate the concern: before/after screenshots for RTL, samples of text expansion, or code patterns for pluralization.</ds-prop>
+</ds-prop-table>
+<ds-heading level="3" anchor="section-section">Section (<ds-code inline>section</ds-code>)</ds-heading>
+<p>Free-form narrative prose organized into titled, optionally nested sections — the backbone of conceptual overviews, explanations, rationale, and any reading-oriented content the structured block kinds do not capture. Available on every entity type. Each <ds-code inline>sectionEntry</ds-code> pairs a <ds-code inline>title</ds-code> with an optional rich-text <ds-code inline>body</ds-code>, illustrative <ds-code inline>examples</ds-code>, related <ds-code inline>links</ds-code>, and recursive <ds-code inline>sections</ds-code> for a heading hierarchy. Reach for a structured block kind first; use <ds-code inline>section</ds-code> only for what they cannot express.</p>
+<ds-heading level="4" anchor="section-entry">Section entry</ds-heading>
+<ds-prop-table>
+  <ds-prop name="title" type="string" required>The section heading (e.g., 'Installation', 'Core concepts', 'Why semantic tokens'). Concise enough to render as a heading and to anchor a deep link.</ds-prop>
+  <ds-prop name="anchor" type="string">A stable, URL-safe fragment identifier for deep-linking to this section (e.g., 'installation', 'core-concepts'). MUST be lowercase kebab-case and unique within the parent block. When omitted, tools MAY derive an anchor from the title.<br><small>Pattern: <ds-code inline>^[a-z][a-z0-9-]*$</ds-code></small></ds-prop>
+  <ds-prop name="body" type="&lt;ds-type-ref href=&quot;common-rich-text.html#richtext&quot;&gt;richText&lt;/ds-type-ref&gt;">The prose content of the section. Supports markdown by default. May be omitted when the section exists only to group sub-sections under a heading.</ds-prop>
+  <ds-prop name="examples" type="&lt;ds-type-ref href=&quot;common-example.html#example&quot;&gt;example&lt;/ds-type-ref&gt;[]">Illustrative examples for this section: code snippets, images, videos, or live URLs. Useful for showing a concept in practice within explanatory prose.</ds-prop>
+  <ds-prop name="links" type="&lt;ds-type-ref href=&quot;common-link.html#link&quot;&gt;link&lt;/ds-type-ref&gt;[]">Related links surfaced with this section — 'see also' references, source material, or pointers to other entities and external resources.</ds-prop>
+  <ds-prop name="sections" type="&lt;ds-type-ref href=&quot;document-blocks-section.html#sectionentry&quot;&gt;sectionEntry&lt;/ds-type-ref&gt;[]">Nested sub-sections beneath this one. Each item is itself a sectionEntry, allowing an arbitrarily deep heading hierarchy. Ordering is significant — tools SHOULD render sub-sections in this order.</ds-prop>
 </ds-prop-table>
 <hr />
 <ds-heading level="2" anchor="component-scoped-document-block-types">Component-scoped document block types</ds-heading>
@@ -843,18 +854,7 @@
 </ds-prop-table>
 <hr />
 <ds-heading level="2" anchor="guide-scoped-document-block-types">Guide-scoped document block types</ds-heading>
-<p>These document block types are accepted on <strong>guide</strong> entities (which also accept <ds-code inline>import</ds-code> and all general document block types). They favor reading-oriented prose and procedures over the measurable specs used by components.</p>
-<ds-heading level="3" anchor="section-section">Section (<ds-code inline>section</ds-code>)</ds-heading>
-<p>Narrative prose organized into titled, optionally nested sections — the backbone of conceptual overviews, explanations, and rationale. Each <ds-code inline>sectionEntry</ds-code> pairs a <ds-code inline>title</ds-code> with an optional rich-text <ds-code inline>body</ds-code>, illustrative <ds-code inline>examples</ds-code>, related <ds-code inline>links</ds-code>, and recursive <ds-code inline>sections</ds-code> for a heading hierarchy.</p>
-<ds-heading level="4" anchor="section-entry">Section entry</ds-heading>
-<ds-prop-table>
-  <ds-prop name="title" type="string" required>The section heading (e.g., 'Installation', 'Core concepts', 'Why semantic tokens'). Concise enough to render as a heading and to anchor a deep link.</ds-prop>
-  <ds-prop name="anchor" type="string">A stable, URL-safe fragment identifier for deep-linking to this section (e.g., 'installation', 'core-concepts'). MUST be lowercase kebab-case and unique within the parent block. When omitted, tools MAY derive an anchor from the title.<br><small>Pattern: <ds-code inline>^[a-z][a-z0-9-]*$</ds-code></small></ds-prop>
-  <ds-prop name="body" type="&lt;ds-type-ref href=&quot;common-rich-text.html#richtext&quot;&gt;richText&lt;/ds-type-ref&gt;">The prose content of the section. Supports markdown by default. May be omitted when the section exists only to group sub-sections under a heading.</ds-prop>
-  <ds-prop name="examples" type="&lt;ds-type-ref href=&quot;common-example.html#example&quot;&gt;example&lt;/ds-type-ref&gt;[]">Illustrative examples for this section: code snippets, images, videos, or live URLs. Useful for showing a concept in practice within explanatory prose.</ds-prop>
-  <ds-prop name="links" type="&lt;ds-type-ref href=&quot;common-link.html#link&quot;&gt;link&lt;/ds-type-ref&gt;[]">Related links surfaced with this section — 'see also' references, source material, or pointers to other entities and external resources.</ds-prop>
-  <ds-prop name="sections" type="&lt;ds-type-ref href=&quot;document-blocks-section.html#sectionentry&quot;&gt;sectionEntry&lt;/ds-type-ref&gt;[]">Nested sub-sections beneath this one. Each item is itself a sectionEntry, allowing an arbitrarily deep heading hierarchy. Ordering is significant — tools SHOULD render sub-sections in this order.</ds-prop>
-</ds-prop-table>
+<p>The <ds-code inline>steps</ds-code> block is accepted only on <strong>guide</strong> entities. Guides also accept <ds-code inline>import</ds-code> and every general document block type — including the free-form <ds-code inline>section</ds-code> block (documented above), which carries a guide's narrative prose.</p>
 <ds-heading level="3" anchor="steps-steps">Steps (<ds-code inline>steps</ds-code>)</ds-heading>
 <p>An ordered (or unordered) procedure — the sequence of steps a reader follows to install, build, contribute, or migrate. The block carries an optional <ds-code inline>title</ds-code> and an <ds-code inline>ordered</ds-code> flag (default <ds-code inline>true</ds-code>); set <ds-code inline>ordered: false</ds-code> for an independent checklist.</p>
 <ds-heading level="4" anchor="step-entry">Step entry</ds-heading>

--- a/spec/examples/entities/foundation.json
+++ b/spec/examples/entities/foundation.json
@@ -374,6 +374,23 @@
             "gaps"
           ]
         }
+      },
+      {
+        "kind": "section",
+        "items": [
+          {
+            "title": "Why a 4px base unit",
+            "anchor": "why-4px-base",
+            "body": "The scale is built on a 4px base. Doubling and adding from that base keeps adjacent steps visually distinct while staying dense enough for data-heavy UI. A 4px grid also aligns cleanly with common icon and line-height values, so spacing and typography share one rhythm.",
+            "sections": [
+              {
+                "title": "When to break the scale",
+                "anchor": "breaking-the-scale",
+                "body": "Deviate only for optical alignment the scale cannot express — for example, nudging an icon by 1px so it sits on its baseline. Document any such exception next to the component that needs it."
+              }
+            ]
+          }
+        ]
       }
     ],
     "agents": {

--- a/spec/examples/entities/pattern.json
+++ b/spec/examples/entities/pattern.json
@@ -470,6 +470,16 @@
             "a11y"
           ]
         }
+      },
+      {
+        "kind": "section",
+        "items": [
+          {
+            "title": "Why centralize error messaging",
+            "anchor": "why-centralize",
+            "body": "Errors surface across forms, asynchronous actions, and failed page loads. Centralizing the rules keeps tone, placement, and recovery consistent, so users learn a single mental model for \"something went wrong\" instead of relearning it on every surface."
+          }
+        ]
       }
     ],
     "agents": {

--- a/spec/schema/document-blocks/document-blocks.schema.json
+++ b/spec/schema/document-blocks/document-blocks.schema.json
@@ -2,10 +2,10 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://designsystemdocspec.org/v0.5/document-blocks/document-blocks.schema.json",
   "title": "DSDS Document Block — Scoped Unions",
-  "description": "Defines scoped document block unions, one per artifact type. Each piece of structured docs attached to an artifact is a document block object with a `type` tag. Block kinds include guidelines, anatomy, API specs, variants, states, accessibility, purpose, design specs, principles, scales, motion, content, and interactions. Each artifact type accepts only the relevant block kinds; this scoping prevents attaching irrelevant docs (such as an API spec on a foundation). Express internal artifact links through the unified `links` array on each entity, not through a dedicated block kind.",
+  "description": "Defines scoped document block unions, one per artifact type. Each piece of structured docs attached to an artifact is a document block object with a `kind` tag. Each artifact type accepts its own specialized block kinds plus every general kind (see `generalDocumentBlock`). General kinds — including the free-form `section` block — are available on every artifact; specialized kinds are scoped so irrelevant docs (such as an API spec on a foundation) cannot be attached. Express internal artifact links through the unified `links` array on each entity, not through a dedicated block kind.",
   "$defs": {
     "generalDocumentBlock": {
-      "description": "A document block kind available on every artifact type. General blocks cover cross-cutting concerns that apply to any artifact.",
+      "description": "A document block kind available on every artifact type. General blocks cover cross-cutting concerns that apply to any artifact, including free-form narrative prose. Every scoped union includes these kinds by referencing this definition.",
       "oneOf": [
         {
           "$ref": "guideline.schema.json#/$defs/guideline",
@@ -22,11 +22,15 @@
         {
           "$ref": "content.schema.json#/$defs/content",
           "description": "Structured content guidelines: recommended action labels with definitions, usage context, and cross-references, plus localization and i18n considerations."
+        },
+        {
+          "$ref": "section.schema.json#/$defs/section",
+          "description": "Free-form narrative prose organized into titled, optionally nested sections — for conceptual content the structured block kinds do not capture: rationale, background, decision history, and FAQs. Reach for a structured block kind first; use `section` only for what they cannot express."
         }
       ]
     },
     "componentDocumentBlock": {
-      "description": "A document block kind accepted on component artifacts. Includes the component-specific kinds (anatomy, API, variants, states, design specs) plus every general kind.",
+      "description": "A document block kind accepted on component artifacts. Includes the component-specific kinds (import, anatomy, API, events, variants, states, design specs) plus every general kind.",
       "oneOf": [
         {
           "$ref": "import.schema.json#/$defs/import",
@@ -57,16 +61,8 @@
           "description": "Measurable visual specs: token inventory, spacing relationships, dimension constraints, typography settings, and responsive behavior."
         },
         {
-          "$ref": "guideline.schema.json#/$defs/guideline"
-        },
-        {
-          "$ref": "../common/purpose.schema.json#/$defs/purpose"
-        },
-        {
-          "$ref": "accessibility.schema.json#/$defs/accessibility"
-        },
-        {
-          "$ref": "content.schema.json#/$defs/content"
+          "$ref": "#/$defs/generalDocumentBlock",
+          "description": "Any general block kind: guideline, purpose, accessibility, content, or a free-form section."
         }
       ]
     },
@@ -86,21 +82,13 @@
           "description": "Named easing curves with cubic-bezier functions (aligned with the DTCG cubicBezier type), recommended durations, and usage guidance for the motion system."
         },
         {
-          "$ref": "guideline.schema.json#/$defs/guideline"
-        },
-        {
-          "$ref": "../common/purpose.schema.json#/$defs/purpose"
-        },
-        {
-          "$ref": "accessibility.schema.json#/$defs/accessibility"
-        },
-        {
-          "$ref": "content.schema.json#/$defs/content"
+          "$ref": "#/$defs/generalDocumentBlock",
+          "description": "Any general block kind: guideline, purpose, accessibility, content, or a free-form section."
         }
       ]
     },
     "patternDocumentBlock": {
-      "description": "A document block kind accepted on pattern artifacts. Includes the pattern-specific kinds (interactions), shared structural kinds (anatomy, variants, states), and every general kind.",
+      "description": "A document block kind accepted on pattern artifacts. Includes the pattern-specific kind (interactions), shared structural kinds (anatomy, variants, states, events), and every general kind.",
       "oneOf": [
         {
           "$ref": "interaction.schema.json#/$defs/interactions",
@@ -123,43 +111,23 @@
           "description": "Events emitted during the pattern's interaction flow: trigger conditions, return shapes, and lifecycle metadata."
         },
         {
-          "$ref": "guideline.schema.json#/$defs/guideline"
-        },
-        {
-          "$ref": "../common/purpose.schema.json#/$defs/purpose"
-        },
-        {
-          "$ref": "accessibility.schema.json#/$defs/accessibility"
-        },
-        {
-          "$ref": "content.schema.json#/$defs/content"
+          "$ref": "#/$defs/generalDocumentBlock",
+          "description": "Any general block kind: guideline, purpose, accessibility, content, or a free-form section."
         }
       ]
     },
     "tokenDocumentBlock": {
-      "description": "A document block kind accepted on token and token group artifacts. Tokens use only the general kinds; they do not have component-specific, foundation-specific, or pattern-specific docs.",
+      "description": "A document block kind accepted on token and token group artifacts. Tokens carry no component-, foundation-, or pattern-specific docs — only the general kinds (guideline, purpose, accessibility, content, and free-form sections).",
       "oneOf": [
         {
-          "$ref": "guideline.schema.json#/$defs/guideline"
-        },
-        {
-          "$ref": "../common/purpose.schema.json#/$defs/purpose"
-        },
-        {
-          "$ref": "accessibility.schema.json#/$defs/accessibility"
-        },
-        {
-          "$ref": "content.schema.json#/$defs/content"
+          "$ref": "#/$defs/generalDocumentBlock",
+          "description": "Any general block kind: guideline, purpose, accessibility, content, or a free-form section."
         }
       ]
     },
     "guideDocumentBlock": {
-      "description": "A document block kind accepted on guide artifacts. Includes the guide-specific narrative kinds (section, steps) plus reused kinds: import (for setup and install instructions), and every general kind. Guides are reading-oriented, so their blocks favor prose and procedures over the measurable specs (api, anatomy, design specs) used by components.",
+      "description": "A document block kind accepted on guide artifacts. Includes the guide-specific procedure kind (steps), the reused import kind (setup and install instructions), and every general kind — among them the free-form `section` block that forms the backbone of conceptual guides. Guides are reading-oriented, so their blocks favor prose and procedures over the measurable specs (api, anatomy, design specs) used by components.",
       "oneOf": [
-        {
-          "$ref": "section.schema.json#/$defs/section",
-          "description": "Narrative prose organized into titled, optionally nested sections. The backbone of conceptual overviews, explanations, and rationale."
-        },
         {
           "$ref": "steps.schema.json#/$defs/steps",
           "description": "An ordered or unordered procedure: the sequence of steps a reader follows to install, build, contribute, or migrate."
@@ -169,16 +137,8 @@
           "description": "How to install and import the system or a package across platforms — package names, import statements, and setup context. Useful in getting-started guides."
         },
         {
-          "$ref": "guideline.schema.json#/$defs/guideline"
-        },
-        {
-          "$ref": "../common/purpose.schema.json#/$defs/purpose"
-        },
-        {
-          "$ref": "accessibility.schema.json#/$defs/accessibility"
-        },
-        {
-          "$ref": "content.schema.json#/$defs/content"
+          "$ref": "#/$defs/generalDocumentBlock",
+          "description": "Any general block kind: guideline, purpose, accessibility, content, or a free-form section."
         }
       ]
     }

--- a/spec/schema/dsds.bundled.schema.json
+++ b/spec/schema/dsds.bundled.schema.json
@@ -2313,7 +2313,7 @@
       "additionalProperties": false
     },
     "generalDocumentBlock": {
-      "description": "A document block kind available on every artifact type. General blocks cover cross-cutting concerns that apply to any artifact.",
+      "description": "A document block kind available on every artifact type. General blocks cover cross-cutting concerns that apply to any artifact, including free-form narrative prose. Every scoped union includes these kinds by referencing this definition.",
       "oneOf": [
         {
           "$ref": "#/$defs/guideline",
@@ -2330,11 +2330,15 @@
         {
           "$ref": "#/$defs/content",
           "description": "Structured content guidelines: recommended action labels with definitions, usage context, and cross-references, plus localization and i18n considerations."
+        },
+        {
+          "$ref": "#/$defs/section",
+          "description": "Free-form narrative prose organized into titled, optionally nested sections — for conceptual content the structured block kinds do not capture: rationale, background, decision history, and FAQs. Reach for a structured block kind first; use `section` only for what they cannot express."
         }
       ]
     },
     "componentDocumentBlock": {
-      "description": "A document block kind accepted on component artifacts. Includes the component-specific kinds (anatomy, API, variants, states, design specs) plus every general kind.",
+      "description": "A document block kind accepted on component artifacts. Includes the component-specific kinds (import, anatomy, API, events, variants, states, design specs) plus every general kind.",
       "oneOf": [
         {
           "$ref": "#/$defs/import",
@@ -2365,16 +2369,8 @@
           "description": "Measurable visual specs: token inventory, spacing relationships, dimension constraints, typography settings, and responsive behavior."
         },
         {
-          "$ref": "#/$defs/guideline"
-        },
-        {
-          "$ref": "#/$defs/purpose"
-        },
-        {
-          "$ref": "#/$defs/accessibility"
-        },
-        {
-          "$ref": "#/$defs/content"
+          "$ref": "#/$defs/generalDocumentBlock",
+          "description": "Any general block kind: guideline, purpose, accessibility, content, or a free-form section."
         }
       ]
     },
@@ -2394,21 +2390,13 @@
           "description": "Named easing curves with cubic-bezier functions (aligned with the DTCG cubicBezier type), recommended durations, and usage guidance for the motion system."
         },
         {
-          "$ref": "#/$defs/guideline"
-        },
-        {
-          "$ref": "#/$defs/purpose"
-        },
-        {
-          "$ref": "#/$defs/accessibility"
-        },
-        {
-          "$ref": "#/$defs/content"
+          "$ref": "#/$defs/generalDocumentBlock",
+          "description": "Any general block kind: guideline, purpose, accessibility, content, or a free-form section."
         }
       ]
     },
     "patternDocumentBlock": {
-      "description": "A document block kind accepted on pattern artifacts. Includes the pattern-specific kinds (interactions), shared structural kinds (anatomy, variants, states), and every general kind.",
+      "description": "A document block kind accepted on pattern artifacts. Includes the pattern-specific kind (interactions), shared structural kinds (anatomy, variants, states, events), and every general kind.",
       "oneOf": [
         {
           "$ref": "#/$defs/interactions",
@@ -2431,43 +2419,23 @@
           "description": "Events emitted during the pattern's interaction flow: trigger conditions, return shapes, and lifecycle metadata."
         },
         {
-          "$ref": "#/$defs/guideline"
-        },
-        {
-          "$ref": "#/$defs/purpose"
-        },
-        {
-          "$ref": "#/$defs/accessibility"
-        },
-        {
-          "$ref": "#/$defs/content"
+          "$ref": "#/$defs/generalDocumentBlock",
+          "description": "Any general block kind: guideline, purpose, accessibility, content, or a free-form section."
         }
       ]
     },
     "tokenDocumentBlock": {
-      "description": "A document block kind accepted on token and token group artifacts. Tokens use only the general kinds; they do not have component-specific, foundation-specific, or pattern-specific docs.",
+      "description": "A document block kind accepted on token and token group artifacts. Tokens carry no component-, foundation-, or pattern-specific docs — only the general kinds (guideline, purpose, accessibility, content, and free-form sections).",
       "oneOf": [
         {
-          "$ref": "#/$defs/guideline"
-        },
-        {
-          "$ref": "#/$defs/purpose"
-        },
-        {
-          "$ref": "#/$defs/accessibility"
-        },
-        {
-          "$ref": "#/$defs/content"
+          "$ref": "#/$defs/generalDocumentBlock",
+          "description": "Any general block kind: guideline, purpose, accessibility, content, or a free-form section."
         }
       ]
     },
     "guideDocumentBlock": {
-      "description": "A document block kind accepted on guide artifacts. Includes the guide-specific narrative kinds (section, steps) plus reused kinds: import (for setup and install instructions), and every general kind. Guides are reading-oriented, so their blocks favor prose and procedures over the measurable specs (api, anatomy, design specs) used by components.",
+      "description": "A document block kind accepted on guide artifacts. Includes the guide-specific procedure kind (steps), the reused import kind (setup and install instructions), and every general kind — among them the free-form `section` block that forms the backbone of conceptual guides. Guides are reading-oriented, so their blocks favor prose and procedures over the measurable specs (api, anatomy, design specs) used by components.",
       "oneOf": [
-        {
-          "$ref": "#/$defs/section",
-          "description": "Narrative prose organized into titled, optionally nested sections. The backbone of conceptual overviews, explanations, and rationale."
-        },
         {
           "$ref": "#/$defs/steps",
           "description": "An ordered or unordered procedure: the sequence of steps a reader follows to install, build, contribute, or migrate."
@@ -2477,16 +2445,8 @@
           "description": "How to install and import the system or a package across platforms — package names, import statements, and setup context. Useful in getting-started guides."
         },
         {
-          "$ref": "#/$defs/guideline"
-        },
-        {
-          "$ref": "#/$defs/purpose"
-        },
-        {
-          "$ref": "#/$defs/accessibility"
-        },
-        {
-          "$ref": "#/$defs/content"
+          "$ref": "#/$defs/generalDocumentBlock",
+          "description": "Any general block kind: guideline, purpose, accessibility, content, or a free-form section."
         }
       ]
     },


### PR DESCRIPTION
## Summary

Promotes the free-form `section` document block from **guide-only** to a **general** block kind, so every entity — component, foundation, pattern, token, guide — can carry narrative content (rationale, background, decision history, FAQs) that the structured block kinds don't capture.

Motivated by the foundation/pattern schemas being too limiting for free-form content; this delivers the same capability guides already had, everywhere.

## Changes
- **Schema:** `section` added to `generalDocumentBlock`. The five per-entity unions now `$ref` `generalDocumentBlock` instead of inlining the four general kinds — reviving the previously-dead def so future general additions propagate from one place.
- **Tooling:** `render-summaries.js` expands the nested `generalDocumentBlock` ref, so the per-entity scope/applies tables keep listing the general kinds.
- **Examples:** demonstrative `section` blocks added to `foundation.json` (with a nested sub-section) and `pattern.json`.
- **Docs:** `section` moved from the *Guide-scoped* group into *General* on the schema-architecture page; scope prose corrected throughout.
- Bundle + site regenerated; `package.json` → `0.5.1`; CHANGELOG `[0.5.1]` entry added.

## Compatibility
**Additive and non-breaking.** Schema `$id` stays at `/v0.5/`; documents pinned to v0.5 keep validating and gain the new capability. No `steps`-on-patterns change (deferred until a concrete use).

## Verification
- `npm run validate` → **184 passed, 0 failed**
- Coverage guard: every document-block kind surfaced on the page; all fixture keys resolve
- Scope table verified: Foundation `principles, scale, motion + general`; Token `general only`; `section` scope = General

🤖 Generated with [Claude Code](https://claude.com/claude-code)