### PR TITLE
fix: correct stale version string in Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ No changelog entry, no version bump, no new `/v<n>/` artifact. Commit the regene
 
 ## Contributing
 
-This is an early-stage specification (v0.6). Feedback is welcome:
+This is an early-stage specification (v0.12.0). Feedback is welcome:
 
 - **Open an issue** for questions, suggestions, or problems with the spec.
 - **Open a PR** for proposed changes to the spec, schema, or examples.


### PR DESCRIPTION
The Contributing section reads "This is an early-stage specification (v0.6)" — but the spec is at v0.12.0. This one-line fix brings the README in sync with the actual version.

No schema changes, no version bump, no new versioned bundle — purely a prose correction.