### PR TITLE
feat: [#26] Add agent skills for DSDS spec authoring

### DIFF
--- a/.agents/skills/dsds-add/SKILL.md
+++ b/.agents/skills/dsds-add/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: dsds-add
+description: Author a new Design System Doc Spec (DSDS) spec from component implementation, Figma design, or written requirements. Triggers on "add spec", "create spec", "new spec", "author spec", "spec from component", "spec from Figma".
+metadata:
+  version: 0.1.0
+---
+
+# Add a DSDS Spec
+
+Create a new `.dsds.json` entity file in `packages/specs/`.
+
+## Procedure
+
+1. Determine entity kind: `component`, `token-group`, `theme`, `foundation`, `pattern`, or `guide`.
+2. Gather inputs — read the source (component source code, Figma frame, requirements doc).
+3. Create `{directory}/{identifier}.dsds.json` using the template below.
+4. Add a `$ref` entry in `index.dsds.json` under the correct entity group.
+5. Run `npm run validate -w packages/specs` — fix errors until it passes.
+6. Run `npm run build -w packages/specs` to regenerate the index.
+
+## File Placement
+
+| Kind                | Directory      |
+| ------------------- | -------------- |
+| component           | `components/`  |
+| token-group / token | `tokens/`      |
+| theme               | `themes/`      |
+| foundation          | `foundations/` |
+| pattern             | `patterns/`    |
+| guide               | `guides/`      |
+
+## Template (Component)
+
+```json
+{
+  "$schema": "https://designsystemdocspec.org/v0.15.2/dsds.bundled.schema.json",
+  "dsdsVersion": "0.15.2",
+  "entity": {
+    "kind": "component",
+    "identifier": "<filename-without-extension>",
+    "name": "<PascalCase>",
+    "description": "<one-sentence summary>",
+    "metadata": {
+      "status": { "overall": "draft" },
+      "since": "<version>",
+      "category": "<action|feedback|form|disclosure|overlay|navigation|layout>",
+      "tags": [],
+      "summary": "<short phrase>"
+    },
+    "documentBlocks": []
+  }
+}
+```
+
+## Required Document Blocks (Components)
+
+Include at minimum: `imports`, `anatomy`, `api`, `accessibility`, `guidelines`.
+
+Add when applicable: `use-cases`, `variants`, `states`, `agentDocumentBlocks`.
+
+## Extraction Guidelines
+
+- **From code**: Map props → `api.properties`, CSS class anatomy → `anatomy.parts`, data attributes → `dataAttributes`.
+- **From Figma**: Map layers → `anatomy.parts`, component properties → `api.properties` or `variants`, variable bindings → token references.
+- **From requirements**: Map acceptance criteria → `guidelines`, interaction requirements → `accessibility.keyboardInteractions`.
+
+## Schema References
+
+When unsure about field shapes or required properties, consult:
+
+- **Bundled schema** (in-repo): `packages/specs/schema/dsds.bundled.schema.json`
+- **Entity docs**: `https://designsystemdocspec.org/entities-{kind}` (e.g. `/entities-component`)
+- **Block docs**: `https://designsystemdocspec.org/document-blocks-{kind}` (e.g. `/document-blocks-api`)
+- **Quick start examples**: https://designsystemdocspec.org/quickstart#minimal-examples
+
+## Gotchas
+
+- `entity.identifier` must match the filename (e.g. `checkbox` → `checkbox.dsds.json`).
+- Always sort `documentBlocks` in this order: imports, use-cases, anatomy, api, variants, states, accessibility, guidelines.
+- Use RFC 2119 levels in guidelines: `must`, `should`, `should-not`, `must-not`.

--- a/.agents/skills/dsds-add/SKILL.md
+++ b/.agents/skills/dsds-add/SKILL.md
@@ -2,7 +2,7 @@
 name: dsds-add
 description: Author a new Design System Doc Spec (DSDS) spec from component implementation, Figma design, or written requirements. Triggers on "add spec", "create spec", "new spec", "author spec", "spec from component", "spec from Figma".
 metadata:
-  version: 0.1.0
+  version: 0.15.2
 ---
 
 # Add a DSDS Spec

--- a/.agents/skills/dsds-specs/SKILL.md
+++ b/.agents/skills/dsds-specs/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: dsds-specs
+description: Everything about Design System Doc Spec (DSDS) — entity kinds, document blocks, schema structure, and how it fits into the ecosystem. Use when authoring, reviewing, or reasoning about DSDS specs and `*.dsds.json` files.
+metadata:
+  version: 0.1.0
+---
+
+# Design System Doc Spec (DSDS)
+
+[DSDS v0.15.2](https://designsystemdocspec.org/) is a machine-readable JSON format for documenting design systems. DSDS specs are the **single source of truth** — everything else (React components, Figma, docs, AI catalogs) derives from them.
+
+## Schema Sources
+
+When you need precise field-level details beyond this skill, consult these in order:
+
+1. **Bundled schema** (in-repo): `packages/specs/schema/dsds.bundled.schema.json`
+2. **Schema architecture reference**: https://designsystemdocspec.org/schema-architecture
+3. **Quick start with examples**: https://designsystemdocspec.org/quickstart
+4. **GitHub source** (split schemas + examples): https://github.com/somerandomdude/design-system-documentation-schema/tree/main/spec
+
+Key pages for block-level detail:
+
+- Entity docs: https://designsystemdocspec.org/entities-component, `/entities-token`, `/entities-theme`, `/entities-foundation`, `/entities-pattern`, `/entities-guide`
+- Block docs: https://designsystemdocspec.org/document-blocks-api, `/document-blocks-anatomy`, `/document-blocks-variants`, `/document-blocks-states`, `/document-blocks-accessibility`, `/document-blocks-guidelines`
+
+## Entity Kinds
+
+| Kind          | Purpose                                        | Directory      |
+| ------------- | ---------------------------------------------- | -------------- |
+| `component`   | Component API, anatomy, variants, states, a11y | `components/`  |
+| `token`       | Single design token                            | `tokens/`      |
+| `token-group` | Group of related tokens                        | `tokens/`      |
+| `theme`       | Named token override set                       | `themes/`      |
+| `foundation`  | Principles and scales (color, spacing, type)   | `foundations/` |
+| `pattern`     | Multi-component UX flows                       | `patterns/`    |
+| `guide`       | Narrative documentation                        | `guides/`      |
+| `chunk`       | Pre-composed code patterns                     | `chunks/`      |
+
+## Document Structure
+
+Every `.dsds.json` file has:
+
+```json
+{
+  "$schema": "https://designsystemdocspec.org/v0.15.2/dsds.bundled.schema.json",
+  "dsdsVersion": "0.15.2",
+  "entity": { "kind": "...", "identifier": "...", ... }
+}
+```
+
+The root index (`index.dsds.json`) uses `entityGroups` with `$ref` links instead of `entity`.
+
+## Component Document Blocks
+
+Blocks inside `entity.documentBlocks`:
+
+- **imports** — platform-specific import statements
+- **use-cases** — recommended/discouraged usage with alternatives
+- **anatomy** — named parts with token references
+- **api** — properties, events, data attributes (per platform)
+- **variants** — enum and flag variant definitions with tokens
+- **states** — interactive states with token overrides
+- **accessibility** — keyboard interactions, ARIA, focus behaviors
+- **guidelines** — usage rules with RFC 2119 conformance levels
+
+## Agent Document Blocks
+
+`entity.agentDocumentBlocks` — same block kinds but targeted at AI consumers. Use for hard rules agents must follow (e.g. "must-not generate icon-only Button").
+
+## Schema Validation
+
+The bundled schema is at `packages/specs/schema/dsds.bundled.schema.json`. Uses JSON Schema draft 2020-12. Validate with:
+
+```bash
+npm run validate -w packages/specs
+```
+
+## Deep-Dive References
+
+Fetch these pages when authoring specific block types:
+
+| Block         | Reference                                                             |
+| ------------- | --------------------------------------------------------------------- |
+| API           | https://designsystemdocspec.org/document-blocks-api                   |
+| Anatomy       | https://designsystemdocspec.org/document-blocks-anatomy               |
+| Variants      | https://designsystemdocspec.org/document-blocks-variants              |
+| States        | https://designsystemdocspec.org/document-blocks-states                |
+| Accessibility | https://designsystemdocspec.org/document-blocks-accessibility         |
+| Guidelines    | https://designsystemdocspec.org/document-blocks-guidelines            |
+| Imports       | https://designsystemdocspec.org/document-blocks-imports               |
+| Design specs  | https://designsystemdocspec.org/document-blocks-design-specifications |
+
+## Gotchas
+
+- `dsdsVersion` must be exactly `"0.15.2"` (string, not number).
+- Root object must have either `entity` (single-entity files) or `entityGroups` (index files), never both.
+- `entity.identifier` must match the filename without `.dsds.json`.
+- Conformance levels: `must`, `should`, `should-not`, `must-not` (lowercase, hyphenated).
+- `metadata.status` can be a string (`"stable"`) or an object with `overall` and `platforms`.

--- a/.agents/skills/dsds-specs/SKILL.md
+++ b/.agents/skills/dsds-specs/SKILL.md
@@ -2,12 +2,12 @@
 name: dsds-specs
 description: Everything about Design System Doc Spec (DSDS) — entity kinds, document blocks, schema structure, and how it fits into the ecosystem. Use when authoring, reviewing, or reasoning about DSDS specs and `*.dsds.json` files.
 metadata:
-  version: 0.1.0
+  version: 0.15.2
 ---
 
 # Design System Doc Spec (DSDS)
 
-[DSDS v0.15.2](https://designsystemdocspec.org/) is a machine-readable JSON format for documenting design systems. DSDS specs are the **single source of truth** — everything else (React components, Figma, docs, AI catalogs) derives from them.
+[DSDS](https://designsystemdocspec.org/) is a machine-readable JSON format for documenting design systems. DSDS specs are the **single source of truth** — everything else (React components, Figma, docs, AI catalogs) derives from them.
 
 ## Schema Sources
 
@@ -92,7 +92,6 @@ Fetch these pages when authoring specific block types:
 
 ## Gotchas
 
-- `dsdsVersion` must be exactly `"0.15.2"` (string, not number).
 - Root object must have either `entity` (single-entity files) or `entityGroups` (index files), never both.
 - `entity.identifier` must match the filename without `.dsds.json`.
 - Conformance levels: `must`, `should`, `should-not`, `must-not` (lowercase, hyphenated).

--- a/.agents/skills/dsds-update/SKILL.md
+++ b/.agents/skills/dsds-update/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: dsds-update
+description: Update an existing DSDS spec based on implementation changes, Figma updates, or written instructions. Triggers on "update spec", "modify spec", "add prop to spec", "sync spec", "spec drift".
+metadata:
+  version: 0.1.0
+---
+
+# Update a DSDS Spec
+
+Modify an existing `.dsds.json` file in `packages/specs/`.
+
+## Procedure
+
+1. Read the existing spec file.
+2. Identify what changed — compare against the source (code diff, Figma update, user instructions).
+3. Apply edits to the spec, preserving structure and existing content.
+4. Run `npm run validate -w packages/specs` — fix errors until it passes.
+5. Run `npm run build -w packages/specs` to regenerate the index.
+
+## Common Updates
+
+| Change                        | Location in spec                               |
+| ----------------------------- | ---------------------------------------------- |
+| New prop                      | `documentBlocks[kind=api].properties`          |
+| New variant value             | `documentBlocks[kind=variants].items[].values` |
+| New state                     | `documentBlocks[kind=states].items`            |
+| Anatomy change                | `documentBlocks[kind=anatomy].parts`           |
+| New accessibility requirement | `documentBlocks[kind=accessibility]`           |
+| Status change                 | `entity.metadata.status`                       |
+| New agent rule                | `agentDocumentBlocks[kind=guidelines].items`   |
+
+## Rules
+
+- Never remove existing content unless explicitly instructed — specs are additive by default.
+- Preserve alphabetical ordering of properties within `api.properties`.
+- When adding variant values, place them in logical order (not necessarily alphabetical).
+- Update `metadata.status` if the change constitutes a breaking API modification.
+- If adding a new relationship, use `{ "relation": "<depends-on|extends|related-to>", "target": "<identifier>", "role": "<description>" }`.
+
+## Schema References
+
+When adding new blocks or fields, verify the exact shape:
+
+- **Bundled schema** (in-repo): `packages/specs/schema/dsds.bundled.schema.json`
+- **Block reference**: `https://designsystemdocspec.org/document-blocks-{kind}`
+- **Entity reference**: `https://designsystemdocspec.org/entities-{kind}`
+- **Full architecture**: https://designsystemdocspec.org/schema-architecture
+
+## Gotchas
+
+- Modifying `entity.identifier` or `entity.kind` is a breaking change — confirm with the user.
+- Adding a required prop (`"required": true`) is a breaking change for consumers.
+- Token references must match identifiers in the `tokens/` specs.

--- a/.agents/skills/dsds-update/SKILL.md
+++ b/.agents/skills/dsds-update/SKILL.md
@@ -2,7 +2,7 @@
 name: dsds-update
 description: Update an existing DSDS spec based on implementation changes, Figma updates, or written instructions. Triggers on "update spec", "modify spec", "add prop to spec", "sync spec", "spec drift".
 metadata:
-  version: 0.1.0
+  version: 0.15.2
 ---
 
 # Update a DSDS Spec

--- a/.agents/skills/dsds-validate/SKILL.md
+++ b/.agents/skills/dsds-validate/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: dsds-validate
+description: Validate DSDS specs against the bundled schema and check for consistency issues. Triggers on "validate specs", "check specs", "spec errors", "run validation".
+metadata:
+  version: 0.1.0
+---
+
+# Validate DSDS Specs
+
+Run schema and consistency validation on spec files in `packages/specs/`.
+
+## Quick Command
+
+```bash
+npm run validate -w packages/specs
+```
+
+This runs all `*.dsds.json` files against the DSDS v0.15.2 bundled schema using Ajv2020.
+
+## Full Validation (with tests)
+
+```bash
+npm test -w packages/specs
+```
+
+Checks:
+
+1. Schema compliance (all files validate against `schema/dsds.bundled.schema.json`)
+2. Filename/identifier consistency (`entity.identifier` matches filename)
+
+## Interpreting Failures
+
+| Error pattern                 | Fix                                                                 |
+| ----------------------------- | ------------------------------------------------------------------- |
+| `must have required property` | Add the missing field to the entity or block                        |
+| `must be equal to constant`   | Check `dsdsVersion` is `"0.15.2"`                                   |
+| `must match "oneOf"`          | Entity is missing either `entity` or `entityGroups` at root         |
+| Identifier mismatch           | Rename `entity.identifier` to match filename (without `.dsds.json`) |
+
+## Validation Loop
+
+1. Run `npm run validate -w packages/specs`
+2. If errors, fix the first reported file
+3. Re-run validation
+4. Repeat until all pass
+
+## Schema Sources
+
+The validation schema comes from the [DSDS project](https://github.com/somerandomdude/design-system-documentation-schema):
+
+- **Bundled schema** (used by `npm run validate`): `packages/specs/schema/dsds.bundled.schema.json`
+- This is a single-file version with all `$ref`s inlined from the split schema
+
+If validation fails on a field you're unsure about, consult the relevant docs page:
+
+- https://designsystemdocspec.org/schema-architecture (full field reference)
+- `https://designsystemdocspec.org/document-blocks-{kind}` (per-block constraints)
+- `https://designsystemdocspec.org/entities-{kind}` (per-entity constraints)
+
+## When to Validate
+
+- After creating or modifying any `.dsds.json` file
+- Before committing changes

--- a/.agents/skills/dsds-validate/SKILL.md
+++ b/.agents/skills/dsds-validate/SKILL.md
@@ -2,7 +2,7 @@
 name: dsds-validate
 description: Validate DSDS specs against the bundled schema and check for consistency issues. Triggers on "validate specs", "check specs", "spec errors", "run validation".
 metadata:
-  version: 0.1.0
+  version: 0.15.2
 ---
 
 # Validate DSDS Specs
@@ -33,7 +33,6 @@ Checks:
 | Error pattern                 | Fix                                                                 |
 | ----------------------------- | ------------------------------------------------------------------- |
 | `must have required property` | Add the missing field to the entity or block                        |
-| `must be equal to constant`   | Check `dsdsVersion` is `"0.15.2"`                                   |
 | `must match "oneOf"`          | Entity is missing either `entity` or `entityGroups` at root         |
 | Identifier mismatch           | Rename `entity.identifier` to match filename (without `.dsds.json`) |
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ node_modules
 
 COMPATIBILITY_REPORT.md
 recommendations.md
-skills
 
 test/sanity-ui

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "visualize": "node scripts/visualize.js",
     "readability": "node scripts/readability-audit.mjs",
     "bump-version": "node scripts/bump-version.js",
+    "sync-skill-versions": "node scripts/sync-skill-versions.js",
     "og:generate": "node scripts/generate-og-image.mjs",
     "prebuild": "npm run sync-examples && npm run bundle && npm run og:generate",
     "prevalidate": "npm run sync-examples && npm run bundle",

--- a/scripts/sync-skill-versions.js
+++ b/scripts/sync-skill-versions.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * sync-skill-versions.js — Update agent skill files to match the spec version.
+ *
+ * Rewrites `.agents/skills/dsds-*` SKILL.md files so their YAML frontmatter
+ * `metadata.version`, URL fragments, `dsdsVersion` literals, and any other
+ * remaining version strings all point at the current (or specified) spec
+ * version.
+ *
+ * Usage:
+ *   node scripts/sync-skill-versions.js              # use version from schema
+ *   node scripts/sync-skill-versions.js <version>    # explicit target version
+ *   node scripts/sync-skill-versions.js --dry-run    # preview only
+ *   node scripts/sync-skill-versions.js --help
+ *
+ * When run without a version argument, reads the target from
+ * spec/schema/dsds.schema.json#/properties/dsdsVersion/const — so running
+ * this after bump-version.js picks up the freshly bumped value automatically.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+const ROOT_SCHEMA = path.join(ROOT, "spec", "schema", "dsds.schema.json");
+const SKILLS_DIR = path.join(ROOT, ".agents", "skills");
+
+function printHelp() {
+  console.log(`
+sync-skill-versions — sync agent skill DSDS version references
+
+Usage:
+  node scripts/sync-skill-versions.js [<version>] [--dry-run]
+
+Arguments:
+  <version>    Target version string (ex: 0.15.2). If omitted, reads from
+               spec/schema/dsds.schema.json#/properties/dsdsVersion/const.
+
+Options:
+  --dry-run    Print planned changes without writing files.
+  --help, -h   Show this help.
+`);
+}
+
+const args = process.argv.slice(2);
+if (args.includes("--help") || args.includes("-h")) {
+  printHelp();
+  process.exit(0);
+}
+
+const flags = new Set(args.filter((a) => a.startsWith("--")));
+const positional = args.filter((a) => !a.startsWith("--"));
+const DRY_RUN = flags.has("--dry-run");
+
+let TARGET_VERSION;
+if (positional.length > 1) {
+  console.error("✗ Expected at most one positional argument: <version>");
+  process.exit(1);
+}
+
+if (positional.length === 1) {
+  TARGET_VERSION = positional[0];
+} else {
+  if (!fs.existsSync(ROOT_SCHEMA)) {
+    console.error(`✗ Root schema not found: ${path.relative(ROOT, ROOT_SCHEMA)}`);
+    process.exit(1);
+  }
+  const rootJson = JSON.parse(fs.readFileSync(ROOT_SCHEMA, "utf-8"));
+  TARGET_VERSION =
+    rootJson &&
+    rootJson.properties &&
+    rootJson.properties.dsdsVersion &&
+    rootJson.properties.dsdsVersion.const;
+  if (!TARGET_VERSION) {
+    console.error(
+      "✗ Could not read version from " +
+        `${path.relative(ROOT, ROOT_SCHEMA)}#/properties/dsdsVersion/const`,
+    );
+    process.exit(1);
+  }
+}
+
+if (!/^[A-Za-z0-9]+(\.[A-Za-z0-9-]+)*$/.test(TARGET_VERSION)) {
+  console.error(`✗ Invalid version string: "${TARGET_VERSION}"`);
+  process.exit(1);
+}
+
+const URL_REGEX = /designsystemdocspec\.org\/v([A-Za-z0-9.\-]+)\//g;
+const NEW_URL_FRAGMENT = `designsystemdocspec.org/v${TARGET_VERSION}/`;
+const DSDS_VERSION_LITERAL_REGEX = /("dsdsVersion"\s*:\s*")([A-Za-z0-9.\-]+)(")/g;
+const FRONTMATTER_VERSION_REGEX = /(metadata:\s*\n\s*version:\s*)\S+/;
+
+function rewriteUrlsInText(text) {
+  let count = 0;
+  const updated = text.replace(URL_REGEX, (match, foundVersion) => {
+    if (foundVersion === TARGET_VERSION) return match;
+    count++;
+    return NEW_URL_FRAGMENT;
+  });
+  return { updated, count };
+}
+
+function rewriteDsdsVersionLiterals(text) {
+  let count = 0;
+  const updated = text.replace(DSDS_VERSION_LITERAL_REGEX, (match, before, oldVer, after) => {
+    if (oldVer === TARGET_VERSION) return match;
+    count++;
+    return before + TARGET_VERSION + after;
+  });
+  return { updated, count };
+}
+
+if (!fs.existsSync(SKILLS_DIR)) {
+  console.log("No .agents/skills directory found — nothing to do.");
+  process.exit(0);
+}
+
+const skillFiles = fs.readdirSync(SKILLS_DIR, { withFileTypes: true })
+  .filter((d) => d.isDirectory() && d.name.startsWith("dsds-"))
+  .map((d) => path.join(SKILLS_DIR, d.name, "SKILL.md"))
+  .filter((p) => fs.existsSync(p));
+
+if (skillFiles.length === 0) {
+  console.log("No dsds-* skill files found — nothing to do.");
+  process.exit(0);
+}
+
+const schemaJson = JSON.parse(fs.readFileSync(ROOT_SCHEMA, "utf-8"));
+const CURRENT_SCHEMA_VERSION =
+  schemaJson.properties.dsdsVersion.const;
+
+console.log(`Syncing agent skill versions to v${TARGET_VERSION}`);
+if (DRY_RUN) console.log("(dry run — no files will be written)");
+console.log();
+
+let totalFiles = 0;
+let totalReplacements = 0;
+const changedFiles = [];
+
+for (const file of skillFiles) {
+  const original = fs.readFileSync(file, "utf-8");
+  let text = original;
+  let count = 0;
+
+  // Frontmatter metadata.version → target version
+  text = text.replace(FRONTMATTER_VERSION_REGEX, (m, prefix) => {
+    if (m.slice(prefix.length) === TARGET_VERSION) return m;
+    count++;
+    return prefix + TARGET_VERSION;
+  });
+
+  // Body: rewrite URLs and dsdsVersion literals
+  let r = rewriteUrlsInText(text);
+  text = r.updated; count += r.count;
+
+  r = rewriteDsdsVersionLiterals(text);
+  text = r.updated; count += r.count;
+
+  // Catch-all: remaining literal version strings the regexes don't cover.
+  if (CURRENT_SCHEMA_VERSION !== TARGET_VERSION) {
+    const before = text;
+    text = text.replaceAll(CURRENT_SCHEMA_VERSION, TARGET_VERSION);
+    if (text !== before) {
+      count += before.split(CURRENT_SCHEMA_VERSION).length - 1;
+    }
+  }
+
+  if (text !== original) {
+    totalFiles++;
+    totalReplacements += count;
+    changedFiles.push(path.relative(ROOT, file));
+    if (!DRY_RUN) fs.writeFileSync(file, text, "utf-8");
+  }
+}
+
+if (totalFiles === 0) {
+  console.log(`All skill files already at v${TARGET_VERSION}. Nothing to do.`);
+  process.exit(0);
+}
+
+const action = DRY_RUN ? "Would update" : "Updated";
+console.log(`${action} ${totalFiles} file(s) (${totalReplacements} replacements):`);
+for (const f of changedFiles) console.log(`  ${f}`);
+console.log();
+
+if (DRY_RUN) {
+  console.log("Dry run complete. Rerun without --dry-run to apply.");
+} else {
+  console.log("✓ Skill versions synced.");
+}


### PR DESCRIPTION
> [!NOTE]
> Putting this draft up for discussion, as suggested in #26

## Summary

Adds initial set of agent skills for working with DSDS specs, and updates `bump-version.js` to keep skill versions in sync with the spec.

### Skills Added

| Skill | Purpose |
|---|---|
| `dsds-specs` | Architectural overview — entity kinds, document blocks, schema structure, gotchas |
| `dsds-add` | Step-by-step procedure for creating a new spec from code, Figma, or requirements |
| `dsds-update` | Procedure for modifying an existing spec (new props, states, variants, etc.) |
| `dsds-validate` | How to run validation, interpret errors, and fix common failures |

### Version syncing

`bump-version.js` now updates `.agents/skills/dsds-*/SKILL.md` files on each spec bump:

- Rewrites `metadata.version` in YAML frontmatter to the new spec version
- Rewrites `$schema` URLs and `"dsdsVersion"` literals in JSON templates
- Catches remaining version strings (e.g. "DSDS v0.x.y") via a final `replaceAll` pass
- Respects `--dry-run` and `--schemas-only` flags; skipped if skills doesn't exist

### Other changes

- Removed `skills` from `.gitignore` so the `.agents` directory is tracked
- Removed hardcoded version references from skill prose where possible (gotchas, error tables) — remaining references in JSON templates are handled by `bump-version.js`

Closes #26