### PR TITLE
Round out the CEM interop example: slots, CSS parts & a human-auth…

### DIFF
--- a/spec/examples/interop/ui-badge.custom-elements.json
+++ b/spec/examples/interop/ui-badge.custom-elements.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": "2.1.0",
+  "readme": "README.md",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "ui/ui-badge.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "name": "UiBadge",
+          "tagName": "ui-badge",
+          "description": "A small status/label badge, optionally dismissible.",
+          "members": [
+            {
+              "kind": "field",
+              "name": "variant",
+              "type": { "text": "'neutral' | 'success' | 'warning' | 'danger'" },
+              "default": "'neutral'",
+              "description": "Visual tone of the badge."
+            },
+            {
+              "kind": "field",
+              "name": "dismissible",
+              "type": { "text": "boolean" },
+              "default": "false",
+              "description": "When true, the badge renders a close control and can be dismissed."
+            },
+            {
+              "kind": "method",
+              "name": "dismiss",
+              "description": "Dismisses the badge programmatically and fires the dismiss event.",
+              "return": { "type": { "text": "void" } }
+            }
+          ],
+          "attributes": [
+            { "name": "variant", "fieldName": "variant" },
+            { "name": "dismissible", "fieldName": "dismissible" }
+          ],
+          "events": [
+            {
+              "name": "dismiss",
+              "type": { "text": "CustomEvent" },
+              "description": "Fired after the badge is dismissed."
+            }
+          ],
+          "slots": [
+            { "name": "", "description": "The badge label." }
+          ],
+          "cssProperties": [
+            {
+              "name": "--ui-badge-background",
+              "description": "Background color of the badge.",
+              "default": "var(--color-surface-muted)"
+            },
+            {
+              "name": "--ui-badge-color",
+              "description": "Label text color of the badge."
+            }
+          ],
+          "cssParts": [
+            { "name": "label", "description": "The label text container." },
+            { "name": "close", "description": "The dismiss control, present when dismissible." }
+          ],
+          "superclass": { "name": "HTMLElement" }
+        }
+      ],
+      "exports": [
+        { "kind": "js", "name": "UiBadge", "declaration": { "name": "UiBadge" } },
+        {
+          "kind": "custom-element-definition",
+          "name": "ui-badge",
+          "declaration": { "name": "UiBadge" }
+        }
+      ]
+    }
+  ]
+}

--- a/spec/examples/interop/ui-badge.dsds.json
+++ b/spec/examples/interop/ui-badge.dsds.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://designsystemdocspec.org/v0.15.2/dsds.bundled.schema.json",
+  "dsdsVersion": "0.15.2",
+  "entity": {
+    "kind": "component",
+    "identifier": "ui-badge",
+    "name": "UiBadge",
+    "description": "A small badge for labeling or categorizing content, optionally dismissible. Its API is generated from the component's Custom Elements Manifest; its guidance and accessibility notes are authored by hand.",
+    "metadata": {
+      "docOrigin": {
+        "overall": "authored",
+        "authorship": "human",
+        "note": "API block generated from ui-badge.custom-elements.json (CEM schemaVersion 2.1.0) by cem-to-dsds. Use-cases, guidelines, and accessibility authored by hand.",
+        "blocks": {
+          "api": { "origin": "generated", "authorship": "machine-generated" }
+        }
+      },
+      "links": [
+        {
+          "kind": "manifest",
+          "url": "https://example.com/ui/custom-elements.json",
+          "label": "Custom Elements Manifest"
+        },
+        {
+          "kind": "source",
+          "url": "https://example.com/ui/ui-badge.js",
+          "label": "ui/ui-badge.js"
+        }
+      ],
+      "summary": "A small, optionally dismissible status/label badge."
+    },
+    "documentBlocks": [
+      {
+        "kind": "imports",
+        "items": [
+          {
+            "platform": "web-component",
+            "code": "import 'ui/ui-badge.js';",
+            "description": "Importing the module registers the `<ui-badge>` custom element."
+          }
+        ]
+      },
+      {
+        "kind": "api",
+        "platform": "web-component",
+        "properties": [
+          {
+            "identifier": "variant",
+            "type": "string",
+            "values": ["neutral", "success", "warning", "danger"],
+            "description": "Visual tone of the badge.",
+            "defaultValue": "neutral"
+          },
+          {
+            "identifier": "dismissible",
+            "type": "boolean",
+            "description": "When true, the badge renders a close control and can be dismissed.",
+            "defaultValue": false
+          }
+        ],
+        "events": [
+          {
+            "identifier": "dismiss",
+            "description": "Fired after the badge is dismissed, whether by the close control or the dismiss() method.",
+            "payload": "CustomEvent"
+          }
+        ],
+        "slots": [
+          {
+            "identifier": "default",
+            "description": "The badge label.",
+            "acceptedContent": "Plain text or a text node. Do not nest interactive elements."
+          }
+        ],
+        "cssCustomProperties": [
+          {
+            "identifier": "--ui-badge-background",
+            "description": "Background color of the badge.",
+            "type": "color",
+            "defaultValue": "var(--color-surface-muted)"
+          },
+          {
+            "identifier": "--ui-badge-color",
+            "description": "Label text color of the badge.",
+            "type": "color"
+          }
+        ],
+        "cssParts": [
+          { "identifier": "label", "description": "The label text container." },
+          {
+            "identifier": "close",
+            "description": "The dismiss control, present when dismissible is true."
+          }
+        ],
+        "methods": [
+          {
+            "identifier": "dismiss",
+            "description": "Dismisses the badge programmatically and fires the dismiss event.",
+            "returnType": "void"
+          }
+        ]
+      },
+      {
+        "kind": "use-cases",
+        "items": [
+          {
+            "description": "When you need to label or categorize an item inline, such as a status tag on a list row.",
+            "stance": "recommended"
+          },
+          {
+            "description": "When you need a dismissible marker the user can clear, such as an applied filter chip.",
+            "stance": "recommended"
+          },
+          {
+            "description": "When the element should trigger an action on click.",
+            "stance": "discouraged",
+            "alternative": {
+              "identifier": "button",
+              "rationale": "A badge carries no interactive semantics. An action needs a control that announces itself as one and is keyboard-operable."
+            }
+          }
+        ]
+      },
+      {
+        "kind": "guidelines",
+        "items": [
+          {
+            "guidance": "Do not use a badge as an interactive control. Use a button or a link.",
+            "rationale": "A badge has no role, focus behavior, or keyboard handling of its own. An action placed on it is invisible to assistive technology and unreachable by keyboard.",
+            "level": "must-not",
+            "category": "accessibility"
+          },
+          {
+            "guidance": "Keep badge labels to one or two words.",
+            "rationale": "Badges sit inline in dense contexts. Long labels wrap and break the surrounding layout.",
+            "level": "should",
+            "category": "content"
+          }
+        ]
+      },
+      {
+        "kind": "accessibility",
+        "wcagLevel": "AA",
+        "keyboardInteractions": [
+          {
+            "key": "Enter",
+            "action": "Activates the close control and dismisses the badge.",
+            "context": "When dismissible and the close control has focus."
+          },
+          {
+            "key": "Space",
+            "action": "Activates the close control and dismisses the badge.",
+            "context": "When dismissible and the close control has focus."
+          }
+        ],
+        "colorContrast": [
+          {
+            "foreground": "--ui-badge-color",
+            "background": "--ui-badge-background",
+            "context": "Badge label text on the badge background."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
…ored layer

Hi PJ, and hi to everyone landing in the new Design System Documentation Community Group. I'm Cody Clark — a designer and design engineer. For the last stretch I've been building agent tooling that reads a design system and helps coding agents build against it, and this spec is the thing I kept wishing existed while I did it. So when the group opened, I signed on, and I'd like to actually be useful in it.

You mentioned you'd been carrying most of this on your own. I'd like to take some of that weight where I can. I wanted my first contribution to be work rather than words, so I started in the interoperability examples, which is where a lot of my day-to-day already lives. This is the meatiest of a few I'm opening together; the other two are smaller companions.

What: adds a fuller CEM interoperability example (ui-badge.custom-elements.json
+ ui-badge.dsds.json) that exercises the whole Custom Elements Manifest member set and pairs it with hand-written guidance.

Why: two gaps in the current CEM example. First, it only maps fields, methods, and events, so the slots, CSS custom properties, and CSS parts that CEM also describes never appear, and the mapping table in the interop docs isn't demonstrated end to end. Second, every block is machine-generated with descriptions marked "pending", which leaves the most important half of the story untold: what a human still owns after generation.

What it improves: the new element (<ui-badge>) carries slots, CSS custom properties, and CSS parts in its manifest, and the DSDS api block maps each one, so the full CEM-to-DSDS mapping is visible in a single example. On top of the generated api block it layers authored use-cases, guidelines, and accessibility, with per-block docOrigin recording that the API surface was generated while the guidance was written by hand. That's the pattern worth teaching: generate the interface from the manifest, and keep usage and accessibility human. The CEM file follows schema version 2.1.0; the DSDS side validates against the current bundled schema and the semantic checks.