### PR TITLE
Add a nested/aliased DTCG interop example

### DIFF
--- a/spec/examples/interop/nested-color.dsds.json
+++ b/spec/examples/interop/nested-color.dsds.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://designsystemdocspec.org/v0.15.2/dsds.bundled.schema.json",
+  "dsdsVersion": "0.15.2",
+  "entity": {
+    "kind": "token-group",
+    "identifier": "color",
+    "name": "Color",
+    "tokenType": "color",
+    "source": { "file": "./nested-color.tokens.json", "path": "color" },
+    "children": [
+      {
+        "kind": "token-group",
+        "identifier": "color.palette",
+        "name": "Palette",
+        "source": { "file": "./nested-color.tokens.json", "path": "color.palette" },
+        "children": [
+          {
+            "kind": "token",
+            "identifier": "color.palette.blue-500",
+            "source": { "file": "./nested-color.tokens.json", "path": "color.palette.blue-500" }
+          },
+          {
+            "kind": "token",
+            "identifier": "color.palette.blue-600",
+            "source": { "file": "./nested-color.tokens.json", "path": "color.palette.blue-600" }
+          }
+        ]
+      },
+      {
+        "kind": "token-group",
+        "identifier": "color.action",
+        "name": "Action",
+        "source": { "file": "./nested-color.tokens.json", "path": "color.action" },
+        "children": [
+          {
+            "kind": "token",
+            "identifier": "color.action.primary",
+            "name": "Action Primary",
+            "description": "Background for the single primary action on a surface. The value is an alias into the palette; both live in the DTCG file.",
+            "source": { "file": "./nested-color.tokens.json", "path": "color.action.primary" },
+            "relationships": [
+              {
+                "relation": "depends-on",
+                "target": "color.palette.blue-500",
+                "role": "resolves its value from this primitive (DTCG alias)"
+              }
+            ],
+            "documentBlocks": [
+              {
+                "kind": "guidelines",
+                "items": [
+                  {
+                    "level": "should",
+                    "guidance": "Use for at most one action per surface.",
+                    "rationale": "Two competing primary actions split attention and dilute the hierarchy the color exists to create."
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "token",
+            "identifier": "color.action.primary-hover",
+            "name": "Action Primary Hover",
+            "description": "Hover state for the primary action background.",
+            "source": { "file": "./nested-color.tokens.json", "path": "color.action.primary-hover" },
+            "relationships": [
+              {
+                "relation": "depends-on",
+                "target": "color.palette.blue-600",
+                "role": "resolves its value from this primitive (DTCG alias)"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/spec/examples/interop/nested-color.tokens.json
+++ b/spec/examples/interop/nested-color.tokens.json
@@ -1,0 +1,19 @@
+{
+  "color": {
+    "$type": "color",
+    "palette": {
+      "blue-500": { "$value": "#0055ff" },
+      "blue-600": { "$value": "#0044cc" }
+    },
+    "action": {
+      "primary": {
+        "$value": "{color.palette.blue-500}",
+        "$description": "Primary action color.",
+        "$extensions": {
+          "com.example.tokens-studio": { "figmaStyleId": "S:1a2b3c" }
+        }
+      },
+      "primary-hover": { "$value": "{color.palette.blue-600}" }
+    }
+  }
+}


### PR DESCRIPTION
I said a fuller hello on the CEM interop PR; the short version is that I'm a designer and design engineer, new to the group, and starting where I think I'm most useful: the interop examples. This one is the DTCG-side companion to that PR.

What: adds a second DTCG interoperability example (nested-color.tokens.json + nested-color.dsds.json) alongside the existing flat one.

Why: the current interop example is a single flat token with one literal value. Real DTCG files almost never look like that. They nest tokens into groups, let a group declare $type once so its children inherit it, and alias semantic tokens onto primitives with {group.token} references. None of that is exercised today, so the example under-sells how well the "reference, never embed" model holds up on a real token file.

What it improves: this pair shows the model working on the shape people actually have. The DTCG side nests a primitive "palette" and a semantic "action" group under a "color" group with an inherited $type, and aliases action.primary onto palette.blue-500. The DSDS side documents the same tree with a token-group entity whose children source-reference their nested dot-paths, and models the alias as a depends-on relationship so the dependency is legible to tooling. It also shows where non-DTCG vendor metadata belongs ($extensions in the token file, not the DSDS doc). Validates against the current bundled schema and the semantic checks.