### PR TITLE
Add DSDS-011: flag token descriptions that only restate the token

### DIFF
--- a/rules/rules.yaml
+++ b/rules/rules.yaml
@@ -105,6 +105,26 @@ rules:
       was a separate decision, resolved in 0.9.0 (enum values are lowercase
       kebab-case — `must`, not `MUST`; see CHANGELOG).
 
+  - id: DSDS-011
+    name: token-description-restates-identifier
+    statement: >
+      A token or token-group `description`, when present, SHOULD NOT merely
+      restate the entity's `identifier` or `name`, and SHOULD NOT be only a
+      raw value (a bare hex/rgb/hsl color or a bare dimension).
+    rationale: >
+      Token descriptions are optional and terse by design (see DSDS-005). When
+      an author writes one, it should add what the identifier cannot: the
+      token's role, or when to use it. A description that echoes the name, or
+      restates the value the DTCG file already owns, reads as documented intent
+      while carrying none, which misleads a human and an agent alike.
+    level: should
+    enforcement: lint
+    note: >
+      Deliberately conservative, to avoid false positives: it fires only on an
+      exact name or identifier restatement (after case and punctuation
+      normalization), or a description that is nothing but a value literal. A
+      description that adds any role or usage information is never flagged.
+
   # Graduated to the schema (kept for traceability; do not reuse the IDs):
   # DSDS-010 deprecated-relationship-link — json-schema
   #   (0.14.0 removed link's identifier/role/required surface; `link` now

--- a/scripts/lint-docs.js
+++ b/scripts/lint-docs.js
@@ -248,6 +248,30 @@ const IMPLEMENTATIONS = {
     }
   },
 
+  "token-description-restates-identifier": (entity, pointer, emit) => {
+    if (entity.kind !== "token" && entity.kind !== "token-group") return;
+    const desc = entity.description;
+    if (typeof desc !== "string" || !desc.trim()) return;
+    const raw = desc.trim();
+    const d = normalizeProse(desc);
+    if (!d) return;
+    const id = normalizeProse(entity.identifier || "");
+    const name = normalizeProse(entity.name || "");
+    const restatesName = (id && d === id) || (name && d === name);
+    // A description that is nothing but a color or dimension value literal —
+    // the value the DTCG file already owns, restated as if it were meaning.
+    const isBareValue =
+      /^#[0-9a-f]{3,8}$/i.test(raw) ||
+      /^(rgb|hsl)a?\([^)]*\)$/i.test(raw) ||
+      /^-?\d*\.?\d+(px|rem|em|%|pt|vh|vw)?$/i.test(raw);
+    if (restatesName || isBareValue) {
+      emit(
+        pointer,
+        `${entityLabel(entity)} has a description that only ${restatesName ? "restates its name" : "gives a raw value"} — a token description should state the token's role or when to use it, not repeat what the identifier or the DTCG value already says. Drop it (descriptions are optional) or state its purpose.`,
+      );
+    }
+  },
+
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
I've been spending a lot of time in agent-authored design docs, which is what prompts this. It's a small change to the lint, and I'd rather float the idea than assume it's wanted, I'm curious whether it fits how you think about the catalog.

What: adds one warning-tier lint rule, DSDS-011, to rules/rules.yaml, with its implementation in scripts/lint-docs.js.

Why: the doc lint already asks "is this documentation good?" above what the schema can check, but nothing yet covers token descriptions. Tokens are deliberately description-exempt (DSDS-005 keeps them terse at scale), so the gap isn't missing descriptions. It's the description that gets written and says nothing the identifier didn't already say: color-action-primary described as "Color action primary", or a token described as its own hex value. That reads as documented intent while carrying none, which misleads a human and an agent the same way.

What it improves: DSDS-011 catches exactly that case and nothing else. It fires only when a token or token-group description, after case and punctuation normalization, is an exact restatement of the identifier or name, or is nothing but a value literal (a bare hex, rgb/hsl, or dimension). Anything that adds a role or a usage note is left alone, so the rule stays quiet on real descriptions and never pressures anyone to add one. It follows the DSDS-001 pattern (a rationale must not restate its guidance), lands as a warning that never fails the build, and ships its catalog entry and implementation together to satisfy the lint's drift guard. Verified with a red/green pass: restatements and bare values are flagged; role-stating descriptions stay clean.