### PR TITLE
Add DSDS-16: flag token descriptions that only restate the scale position

### DIFF
--- a/.agents/skills/dsds-specs/SKILL.md
+++ b/.agents/skills/dsds-specs/SKILL.md
@@ -104,7 +104,7 @@ The bundled schema is published at `https://designsystemdocspec.org/v0.20.0/dsds
 npx dsds-validate <files-or-globs>
 ```
 
-See the `dsds-validate` skill for the full rule catalog (`DSDS-01`–`DSDS-15`) and how to interpret failures.
+See the `dsds-validate` skill for the full rule catalog (`DSDS-01`–`DSDS-16`) and how to interpret failures.
 
 ## Deep-Dive References
 

--- a/.agents/skills/dsds-validate/SKILL.md
+++ b/.agents/skills/dsds-validate/SKILL.md
@@ -19,13 +19,13 @@ This validates every file given against the DSDS v0.20.0 bundled schema using Aj
 
 ## Documentation-Quality Checks (advisory)
 
-A second, separate tier (`DSDS-12`–`DSDS-15`) that answers "is this documentation good?" rather than "is this document allowed?" — RFC 2119 keyword casing, a token description that just restates its id, a hard-requirement guideline with no `checkedBy`, a component with no `when-to-use` guidance. Warnings only; never blocks a build on their own. Not part of the published `dsds-validate` package — it runs from a clone of the DSDS repo itself: `node scripts/lint-docs.js <files-or-globs>`.
+A second, separate tier (`DSDS-12`–`DSDS-16`) that answers "is this documentation good?" rather than "is this document allowed?" — RFC 2119 keyword casing, a token description that just restates its id or its scale position, a hard-requirement guideline with no `checkedBy`, a component with no `when-to-use` guidance. Warnings only; never blocks a build on their own. Not part of the published `dsds-validate` package — it runs from a clone of the DSDS repo itself: `node scripts/lint-docs.js <files-or-globs>`.
 
 ## Full Validation
 
 1. Schema compliance (every file validates against the bundled schema)
 2. Semantic rules (`DSDS-01`–`DSDS-11`, via `npx dsds-validate`)
-3. Documentation-quality advisories (`DSDS-12`–`DSDS-15`, informational, repo-only — see above)
+3. Documentation-quality advisories (`DSDS-12`–`DSDS-16`, informational, repo-only — see above)
 
 ## Interpreting Failures
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ Requirement language in DSDS schemas and docs follows RFC 2119: **MUST**,
 **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY**, normative only in
 upper case. See [/conformance](/conformance) for the full conformance rule
 catalog (`DSDS-01` through `DSDS-11`, enforced by the validator, plus the
-advisory `DSDS-12` through `DSDS-15`), the four conformance classes, and how
+advisory `DSDS-12` through `DSDS-16`), the four conformance classes, and how
 a component's status works across platforms. [/stability](/stability) covers
 what can still change before 1.0. The machine-readable catalog is
 `schema/conformance-rules.yaml`; the generated index of every normative

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ without the other two — a rule can't be silently half-removed the way
 
 **A new advisory (documentation-quality) rule** goes in `scripts/lint-docs.js`
 plus the same `schema/conformance-rules.yaml` catalog, with `enforcement:
-lint`. Advisory rules warn; they never fail `npm run check`.
+advisory`. Advisory rules warn; they never fail `npm run check`.
 
 **A new example** (`examples/`) needs an entry in `manifest.json`'s
 `examples` listing, or a link from the page that's supposed to surface it
@@ -98,7 +98,7 @@ One more runs in CI without gating it — the **advisory tier**, meant to be
 visible rather than blocking:
 
 ```bash
-npm run lint  # documentation-quality rules (DSDS-12–DSDS-15)
+npm run lint  # documentation-quality rules (DSDS-12–DSDS-16)
 ```
 
 It can't fail a build; its findings are warnings by design.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Validated example pairs live in [`examples/interop/`](examples/interop/).
 ## Conformance
 
 What it means for a document to follow the DSDS spec — the four conformance
-classes, the three enforcement tiers, and the full `DSDS-01`–`DSDS-15` rule
+classes, the three enforcement tiers, and the full `DSDS-01`–`DSDS-16` rule
 catalog — is documented on the site:
 
 - **[Conformance](https://designsystemdocspec.org/conformance)** — the rule
@@ -99,7 +99,7 @@ This README leaves out schema field listings and example payloads on purpose —
 
 ## Repository layout
 
-- **`schema/`** — The split JSON Schema source (`common/`, `metadata/`, `entries/`, `sections/`), plus the auto-generated `dsds.bundled.yaml` / `dsds.bundled.schema.json` and the `DSDS-01`–`DSDS-15` `conformance-rules.yaml` catalog.
+- **`schema/`** — The split JSON Schema source (`common/`, `metadata/`, `entries/`, `sections/`), plus the auto-generated `dsds.bundled.yaml` / `dsds.bundled.schema.json` and the `DSDS-01`–`DSDS-16` `conformance-rules.yaml` catalog.
 - **`examples/`** — Validated example documents: full base documents, standalone entries per kind, quickstart snippets, interop pairs, and one `invalid/` fixture per semantic rule.
 - **`test/site-components/`** — A regression corpus documenting this repo's own `site/components/` web components as DSDS entries (dogfooding), checked on every `npm run check`.
 - **`scripts/`** — Bundling, validation, composition, and the static site generator.

--- a/schema/conformance-rules.yaml
+++ b/schema/conformance-rules.yaml
@@ -193,3 +193,28 @@
     checked for a `documentBlocks` entry of `kind: use-cases`) - 0.20.0
     folds that content into a `guidelines` section instead of a separate
     block kind, so this checks for that section's presence instead.
+
+- id: DSDS-16
+  name: token-description-restates-scale-position
+  enforcement: advisory
+  title: A token `description`, when present, shouldn't just restate its position on a scale.
+  description: >-
+    A token entry's optional `description` should add what the id can't -
+    the token's role, or when to use it. One that only restates the token's
+    position on a scale ("Shade 900", "Step 500", "Level 6 of the neutral
+    scale") reads as documented intent while carrying none: that ordinal is
+    already in the id and in the token's place among its `metadata.group`
+    siblings. The companion case to DSDS-13 - the scale step, rather than the
+    id or the raw value.
+  note: >-
+    Ported from PR #37 (by Cody Clark), originally proposed as DSDS-012
+    against the pre-0.20.0 entity model - same algorithm (flag a description
+    that reduces to a single leading scale word plus a number, optionally
+    "<word> <n> of the <family> scale"/"ramp"), re-hosted on a token entry's
+    own id/name/description like DSDS-13 was. 0.20.0 has no separate
+    token-group kind, so it checks `kind: token` only. Deliberately
+    conservative: the scale word must lead and be singular, so number-first
+    and plural forms ("Nine weights", "Twelve steps") and a bare
+    family-plus-number ("Neutral 700") are left alone, and any role or usage
+    word stops the match. A description that also restates the id or name is
+    left to DSDS-13, so it is reported once.

--- a/scripts/lint-docs.js
+++ b/scripts/lint-docs.js
@@ -180,6 +180,45 @@ const IMPLEMENTATIONS = {
       );
     }
   },
+
+  // Ported from PR #37 (DSDS-012, by Cody Clark) - the scale-position
+  // companion to token-description-restates-identifier (DSDS-13). Same
+  // algorithm as the original: flag a description that reduces to a single
+  // leading scale word plus a number and nothing else - the ordinal the id
+  // and the token's place among its metadata.group siblings already carry.
+  // Adapted to 0.20.0's model the same way DSDS-13 was: a token entry's own
+  // id/name/description, kind: token only (0.20.0 has no token-group kind).
+  "token-description-restates-scale-position": (entry, emit) => {
+    if (entry.kind !== "token") return;
+    const desc = entry.description;
+    if (typeof desc !== "string" || !desc.trim()) return;
+    const d = normalizeProse(desc);
+    if (!d) return;
+    // A description that restates the id or name is DSDS-13's case; leave it
+    // there so one that is both is reported once, not twice.
+    const id = normalizeProse(entry.id || "");
+    const name = normalizeProse(entry.name || "");
+    if ((id && d === id) || (name && d === name)) return;
+    // A single leading scale word plus a number, and nothing else: "shade
+    // 900", "step 500", "level six", and the phrasal "level 6 of the neutral
+    // scale"/"ramp". Kept deliberately narrow - the scale word must lead and
+    // be singular, so number-first and plural forms ("nine weights", "twelve
+    // steps") and a bare family-plus-number ("neutral 700") are left alone,
+    // and any role or usage word stops the match. See the DSDS-16 note in
+    // schema/conformance-rules.yaml.
+    const SW = "(?:level|step|shade|tint|grade|weight|size|swatch)";
+    const N = "(?:\\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)";
+    const scaleOnly = [
+      new RegExp(`^${SW} ${N}$`),
+      new RegExp(`^${SW} ${N} of the [a-z]+ (?:scale|ramp)$`),
+    ];
+    if (scaleOnly.some((re) => re.test(d))) {
+      emit(
+        "/description",
+        `token "${entry.id}" has a description that only restates its scale position — a token description should state the token's role or when to use it, not repeat the ordinal the id and its place in the scale already carry. Drop it (description is optional here) or state its purpose.`,
+      );
+    }
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/site/content/conformance.mdx
+++ b/site/content/conformance.mdx
@@ -75,7 +75,7 @@ published as a versioned artifact at
 alongside the schema bundle, for a tool that wants to read the rule
 descriptions programmatically instead of scraping this page.
 
-<ds-callout variant="warning" title="DSDS-01–DSDS-15 is a reset id space, not a continuation of pre-0.20.0's:">
+<ds-callout variant="warning" title="DSDS-01–DSDS-16 is a reset id space, not a continuation of pre-0.20.0's:">
 
 Versions through 0.15.2 used a three-digit catalog (`DSDS-001`–`DSDS-006` and similar, in `rules/rules.yaml`) covering a different rewrite of the model entirely. 0.20.0 restarted numbering at `DSDS-01` for a genuinely different rule set — `DSDS-02` here has nothing to do with whatever `DSDS-002` meant before. (0.15.2's own `DSDS-002` was, fittingly, the rule against reusing an identifier — a reminder this reset itself is worth naming explicitly rather than leaving implicit.) If you're citing a rule id from before 0.15.2, say which catalog it's from; a bare `DSDS-0N` is ambiguous across the two.
 
@@ -100,6 +100,7 @@ Versions through 0.15.2 used a three-digit catalog (`DSDS-001`–`DSDS-006` and 
 | `DSDS-13` | A token `description`, when present, shouldn't just restate its id/name or repeat a raw value. |
 | `DSDS-14` | A hard-requirement guideline (must/must-not) with no `checkedBy` at all. |
 | `DSDS-15` | A component entry with no `guidelines` section framed `when-to-use`. |
+| `DSDS-16` | A token `description`, when present, shouldn't just restate its position on a scale. |
 
 {/* /dsds:rule-catalog */}
 


### PR DESCRIPTION
Hey @somerandomdude 

More suggestions, just drafting for now to think it through more. There is this concept where in agent-authored token files when there is an optional description, it echos the token’s step on a scale. It’s basically a companion case to dsds-011, so just floating again rather than assuming it’s wanted. Just curious whether it fits how you see the catalog growing. 

**What:** adds one warning-tier lint rule, `DSDS-012`, to `rules/rules.yaml`, with its implementation in `scripts/lint-docs.js`.

**Why:** DSDS-011 catches a token description that restates its identifier or name, or that is a bare value. It doesn't catch the other empty form — a description that only restates the token's position on a scale: "Shade 900", "Step 500", "Level 6 of the neutral scale". That ordinal is already carried by the identifier and by the token's place in its group, so the description reads as documented intent while carrying none.

**What it improves:** DSDS-012 fires only when the whole description reduces to a single leading scale word plus a number (optionally "<word> <n> of the <family> scale"), and stays silent the moment the description adds any role or usage word.

**Deliberately narrow**: the scale word must lead and be singular, so number-first and plural forms ("Nine weights", "Twelve steps") are left alone — on a token group those usually state its cardinality, which is real information — and so is bare family-plus-number ("Neutral 700"). A description that also restates the identifier or name is left to DSDS-011, so it's reported once. Warning tier, never fails the build; ships its catalog entry and implementation together for the drift guard. Verified red/green: "Shade 900", "Step 500", "Weight 700", "Size four", "Level 6 of the neutral scale", and a token-group "Step 3 of the elevation ramp" are flagged; a role-stating description, a bare "Neutral 700", a cardinality ("Nine weights"), a compound ("Two-step"), and prose that only mentions a step in passing stay clean. The existing spec/examples corpus still lints clean.