### PR TITLE
Update `shared-a11y` accessibility guidelines in starter-kit.dsds.yaml

### DIFF
--- a/examples/base/starter-kit.dsds.yaml
+++ b/examples/base/starter-kit.dsds.yaml
@@ -99,10 +99,199 @@ shared:
   - id: shared-a11y
     name: Shared Accessibility Rules
     description: Cross-cutting accessibility rules, stated once and referenced from every entry they apply to.
+    refs:
+      - href: https://www.w3.org/WAI/WCAG22/quickref/
+        rel: external-link
+        role: WCAG 2.2 quick reference
     sections:
       - kind: guidelines
         for: all
+        title: Perceivable
         items:
+          - id: text-contrast
+            statement: Text and images of text meet a contrast ratio of at least 4.5:1 against their background, or 3:1 at 18pt / 14pt bold and larger.
+            level: must
+            checkedBy: automated
+            checks:
+              - href: ./tests/a11y/contrast.test.ts
+                rel: test
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html
+                rel: external-link
+                role: WCAG 2.2 SC 1.4.3 (AA)
+ 
+          - id: non-text-contrast
+            statement: Interactive boundaries, focus indicators, icons, and any graphic needed to understand the interface meet 3:1 against adjacent colors.
+            level: must
+            checkedBy: assisted
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html
+                rel: external-link
+                role: WCAG 2.2 SC 1.4.11 (AA)
+ 
+          - id: not-color-alone
+            statement: Color is never the only means of conveying information, indicating an action, or distinguishing a visual element. Pair it with text, an icon, or a shape.
+            level: must
+            checkedBy: manual
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html
+                rel: external-link
+                role: WCAG 2.2 SC 1.4.1 (A)
+ 
+          - id: reflow
+            statement: Content reflows to a 320px-wide viewport without loss of information or two-dimensional scrolling. Data tables and images are the only permitted exceptions.
+            level: must
+            checkedBy: assisted
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/reflow.html
+                rel: external-link
+                role: WCAG 2.2 SC 1.4.10 (AA)
+ 
+          - id: text-resize
+            statement: Text scales to 200% without loss of content or function. Size type in relative units, never fixed pixels.
+            level: must
+            checkedBy: assisted
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html
+                rel: external-link
+                role: WCAG 2.2 SC 1.4.4 (AA)
+ 
+      - kind: guidelines
+        for: all
+        title: Operable
+        items:
+          - id: keyboard-operable
+            statement: Every function is reachable and operable from the keyboard alone, with no timing requirement on individual keystrokes.
+            level: must
+            checkedBy: manual
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html
+                rel: external-link
+                role: WCAG 2.2 SC 2.1.1 (A)
+ 
+          - id: no-keyboard-trap
+            statement: Keyboard focus can always be moved away from a component using standard keys. Anything that traps focus deliberately, such as a modal, documents how to leave it.
+            level: must
+            checkedBy: manual
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/no-keyboard-trap.html
+                rel: external-link
+                role: WCAG 2.2 SC 2.1.2 (A)
+ 
+          - id: focus-visible
+            statement: A visible focus indicator is present on every focusable element.
+            level: must
+            checkedBy: assisted
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html
+                rel: external-link
+                role: WCAG 2.2 SC 2.4.7 (AA)
+ 
+          - id: focus-not-obscured
+            statement: A focused element is never entirely hidden behind sticky headers, footers, or overlays.
+            level: must
+            checkedBy: manual
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html
+                rel: external-link
+                role: WCAG 2.2 SC 2.4.11 (AA), new in WCAG 2.2
+ 
+          # I kept the `touch-target` id so existing same-as refs stay
+          # resolving. `target-size` would be the more w3-accurate name (technically),
+          # since the criterion covers all pointer inputs and not just touch.
           - id: touch-target
-            statement: Minimum touch target 44x44px.
+            statement: Pointer targets are at least 24x24 CSS pixels, unless spacing, inline position, or an equivalent alternative exempts them. Aim for 44x44 on touch-first surfaces.
+            level: must
+            checkedBy: automated
+            checks:
+              - href: ./tests/a11y/target-size.test.ts
+                rel: test
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html
+                rel: external-link
+                role: WCAG 2.2 SC 2.5.8 (AA), new in WCAG 2.2
+ 
+          - id: label-in-name
+            statement: An element's accessible name contains the text shown in its visible label, in the same order, so speech input users can address it by what they see.
+            level: must
+            checkedBy: automated
+            checks:
+              - href: ./tests/a11y/label-in-name.test.ts
+                rel: test
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html
+                rel: external-link
+                role: WCAG 2.2 SC 2.5.3 (A)
+ 
+          - id: dismissible-hover-content
+            statement: Content shown on hover or focus can be dismissed without moving the pointer, stays visible while hovered, and persists until dismissed or no longer valid.
+            level: must
+            checkedBy: manual
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/content-on-hover-or-focus.html
+                rel: external-link
+                role: WCAG 2.2 SC 1.4.13 (AA)
+ 
+          - id: reduced-motion
+            statement: >-
+              Non-essential motion is removed or substantially reduced under
+              `prefers-reduced-motion: reduce`. Parallax, autoplaying loops, and
+              large-scale transitions all count.
+            level: must
+            checkedBy: manual
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html
+                rel: external-link
+                role: WCAG 2.2 SC 2.3.3 (AAA), adopted here as a must
+ 
+      - kind: guidelines
+        for: all
+        title: Understandable and robust
+        items:
+          - id: status-messages
+            statement: A status message that does not take focus is announced to assistive technology through an appropriate role or live region.
+            level: must
+            checkedBy: assisted
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html
+                rel: external-link
+                role: WCAG 2.2 SC 4.1.3 (AA)
+ 
+          - id: error-identification
+            statement: A validation error names the field it belongs to and describes what to fix in text, not only by color or position.
+            level: must
+            checkedBy: manual
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html
+                rel: external-link
+                role: WCAG 2.2 SC 3.3.1 (A)
+ 
+          - id: consistent-identification
+            statement: Components with the same function carry the same name, icon, and behavior everywhere they appear in the system.
+            level: must
+            checkedBy: manual
+            evidence:
+              - href: https://www.w3.org/WAI/WCAG22/Understanding/consistent-identification.html
+                rel: external-link
+                role: WCAG 2.2 SC 3.2.4 (AA)
+ 
+          - id: native-semantics-first
+            statement: Use the native element before reaching for a role. An ARIA role is a last resort, and a component that overrides native semantics documents why.
+            level: should
+            checkedBy: manual
+            evidence:
+              - href: https://www.w3.org/TR/using-aria/
+                rel: external-link
+                role: W3C Using ARIA, first rule of ARIA
+ 
+      - kind: guidelines
+        for: agent
+        title: Agent notes
+        items:
+          # `level` mirrors the target's own level, per the DSDS-10 update.
+          - level: should
+            refs:
+              - to: shared-a11y#native-semantics-first
+                rel: same-as
+          - statement: When generating a component, emit the accessible name, keyboard handling, and focus indicator in the first pass. Do not defer them to a follow-up.
             level: must


### PR DESCRIPTION
What i'm proposing (feel free to take or leave!) :
- the shared-a11y entry in the starter kit currently holds one placeholder rule. Since it's what people will copy when setting up their own shared accessibility rules, this replaces it with 18 real rules grouped by WCAG principle, each citing its success criteria in the evidence field.

Two lil notes:
- checkedBy is hopefully as honest as I can make it. 4 of the 18 are automated. Most accessibility naturally rules can't be machine-verified (unfortunately in the big 2026; or is it for the better?) and I think the example is more useful for saying what's automated versus what needs to be manual.
- The existing 44x44 touch target is SC 2.5.5 (AAA). SC 2.5.8 (AA, new in WCAG 2.2) is 24x24. So, the rule now states 24x24 as the requirement and 44x44 as a touch-first goal. Could be left out but figured I'd include.

Only one file touched here on this commit so, hopefully additive and not harmful.